### PR TITLE
Wallets credentials LocalStorage cache

### DIFF
--- a/js/satolist.js
+++ b/js/satolist.js
@@ -9458,10 +9458,22 @@ Platform = function (app, listofnodes) {
                     walletAddress: address,
                 };
 
+                /**
+                 * Proxy object is used here to
+                 * give access to wallet credentials
+                 * populator, without really instantiating
+                 * wallet data. It creates data only when
+                 * requested.
+                 */
                 const proxy = new Proxy(proxyData, {
                     get: (p, num) => {
                         const addressObj = p.getWalletData(p.walletNum);
 
+                        /**
+                         * Once wallet credentials populated
+                         * replacing Proxy object with
+                         * original wallet data.
+                         */
                         self.sdk.addresses.storage.addressesobj[p.walletNum] = addressObj;
 
                         return addressObj[p.walletNum];


### PR DESCRIPTION
## What changes made

- Wallet addresses are cached in LocalStorage.
- Wallet addresses are kept separate for each user.
- No conflicts awaited, as `sdk.addresses.storage.addresses` structure stays the same.
- Keys for each address requested only if app needs them.
- Once keys are requested, they will stay until app not closed.
- Code a little cleaned and optimized.

## Benchmarks
### Before cache optimizations
![Before cache optimizations](https://user-images.githubusercontent.com/22795961/149572594-a559d3b0-f5c5-4a81-a57b-84b0395414fc.png)

### After cache optimizations
![After cache optimizations](https://user-images.githubusercontent.com/22795961/149572620-f7ff4a6a-f61a-421b-b006-aa0628946a70.png)

