### PR TITLE
Fix app dying when video deleted

### DIFF
--- a/components/lenta/index.js
+++ b/components/lenta/index.js
@@ -1968,7 +1968,7 @@ var lenta = (function(){
 
 				var cvv = videosVolume
 
-				if(!player.p) return
+				if(!player || !player.p) return
 
 				if (player.p.setVolume){
 					if (v){


### PR DESCRIPTION
### What happens
Video deletion on "Saved" page was killing the electron app

### More info
Object `players` was an empty object. When trying to read `players[id]` it is `undefined`.

#### Call 1
![Stack_1](https://user-images.githubusercontent.com/22795961/166984942-5738b3fa-36c9-494c-9098-2d644511e552.png)
#### Call 2
![Stack_2](https://user-images.githubusercontent.com/22795961/166984954-352ce538-9532-4c18-ac4a-cf9691997082.png)

