### PR TITLE
Test accounts authorization route

### DIFF
--- a/js/peertube.js
+++ b/js/peertube.js
@@ -164,7 +164,12 @@ PeerTubePocketnet = function (app) {
 		},
 
 		pocketnetAuth: {
-			path: app.test ? 'api/v1/users/blockChainAuth' : 'plugins/pocketnet-auth/router/code-cb',
+			path: () => {
+				return app.test ||
+					app.platform.testaddresses.includes(app.platform.sdk.address.pnet().address)
+					? 'api/v1/users/blockChainAuth'
+					: 'plugins/pocketnet-auth/router/code-cb';
+			},
 			signature: true,
 			method: 'POST',
 			axios: true,

--- a/js/satolist.js
+++ b/js/satolist.js
@@ -228,7 +228,8 @@ Platform = function (app, listofnodes) {
         'PD4us1zniwrJv64xhPyhT2mgNrTvPur9YN',
         'PHiNjAhHbxVb6D8oaVVBe8DGigKuN4QFP6',
         'PANkQ994YKvCMiH8pHR8vtKvGqH9DQt8Bc',
-        'PGvRUM7jXqHdUn7Let2QyTi1t2LHq7RgX7'
+        'PGvRUM7jXqHdUn7Let2QyTi1t2LHq7RgX7',
+        'P9EkPPJPPRYxmK541WJkmH8yBM4GuWDn2m'
     ];
 
     if (window.IpcBridge)


### PR DESCRIPTION
New built-in-server authorisation path (instead of the peertube plugin) for the test accounts

- Dynamically added new path for the test accounts (ready for production)