### PR TITLE
Transports request was not awaited

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pocketnet",
-    "version": "0.7.97",
+    "version": "0.8.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pocketnet",
-            "version": "0.7.97",
+            "version": "0.8.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "aes-js": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "pocketnet",
-    "version": "0.8.1",
-    "cordovaversion": "1.8.1",
-    "cordovaversioncode": "180010",
+    "version": "0.8.2",
+    "cordovaversion": "1.8.2",
+    "cordovaversioncode": "180020",
     "description": "Bastyon desktop application",
     "author": "Pocketnet Community <support@pocketnet.app>",
     "company": "Pocketnet Community",

--- a/proxy16/node/applications.js
+++ b/proxy16/node/applications.js
@@ -196,8 +196,8 @@ var Applications = function(settings, applications = {}, proxy) {
 
         let endFile = path.resolve(dest, meta[key].name)
 
-        return new Promise(function(resolve, reject) {
-            let req = proxy.transports.request({url:meta[key].url})
+        return new Promise(async (resolve, reject) => {
+            let req = await proxy.transports.request({url:meta[key].url})
 
             progress(req, {
                 throttle: 500,                    // Throttle the progress event to 2000ms, defaults to 1000ms

--- a/proxy16/node/applications.js
+++ b/proxy16/node/applications.js
@@ -197,7 +197,16 @@ var Applications = function(settings, applications = {}, proxy) {
         let endFile = path.resolve(dest, meta[key].name)
 
         return new Promise(async (resolve, reject) => {
-            let req = await proxy.transports.request({url:meta[key].url})
+            let req;
+
+            try {
+                req = await proxy.transports.request({url: meta[key].url});
+            } catch(err) {
+                console.log(err);
+                reject(err);
+
+                return;
+            }
 
             progress(req, {
                 throttle: 500,                    // Throttle the progress event to 2000ms, defaults to 1000ms

--- a/proxy16/node/applications.js
+++ b/proxy16/node/applications.js
@@ -235,6 +235,10 @@ var Applications = function(settings, applications = {}, proxy) {
                 }
             })
             .on('error', function (err) {
+                if (err.message === 'aborted') {
+                    return resolve()
+                }
+
                 console.log(err)
                 return reject(err)
             })


### PR DESCRIPTION
### What was done
- 236178e Awaiting **`Promise<Request>`**

```diff
- let req = proxy.transports.request(...)
+ let req = await proxy.transports.request(...)
```
- ea05240 When download canceled, it was producing message "Internal error". Fixed.