### PR TITLE
Do not log fetch errors in video cabinet

### DIFF
--- a/components/videoCabinet/index.js
+++ b/components/videoCabinet/index.js
@@ -178,7 +178,11 @@ var videoCabinet = (function () {
 
 						if (!err.text) err.text = 'GET_VIDEOS_FROM_SERVER_VIDEOCABINET';
 
-					  	sitemessage(helpers.parseVideoServerError(err));
+						if (err.text.message === 'Failed to fetch') {
+							return [];
+						}
+
+						sitemessage(helpers.parseVideoServerError(err));
 
 						return [];
 					});


### PR DESCRIPTION
Videos hosted on old hosts that are currently offline are unreachable, so omitting the error