### PR TITLE
Fixed a memory leak when loading a snapshot database of a Node 

### DIFF
--- a/proxy16/node/applications.js
+++ b/proxy16/node/applications.js
@@ -7,7 +7,7 @@ var path = require('path');
 var Datastore = require('nedb');
 var progress = require('request-progress');
 var targz = require('targz');
-
+const request = require("request");
 
 var Applications = function(settings, applications = {}, proxy) {
     if(!settings) settings = {}
@@ -197,16 +197,7 @@ var Applications = function(settings, applications = {}, proxy) {
         let endFile = path.resolve(dest, meta[key].name)
 
         return new Promise(async (resolve, reject) => {
-            let req;
-
-            try {
-                req = await proxy.transports.request({url: meta[key].url});
-            } catch(err) {
-                console.log(err);
-                reject(err);
-
-                return;
-            }
+            let req = request(meta[key].url);
 
             progress(req, {
                 throttle: 500,                    // Throttle the progress event to 2000ms, defaults to 1000ms


### PR DESCRIPTION
I didn't understand why the async request from proxy16/transports causes a memory leak - perhaps it's worth paying attention to this in order to use the TOR to download large files