### PR TITLE
Show where is video hosted

### DIFF
--- a/components/share/index.css
+++ b/components/share/index.css
@@ -732,7 +732,7 @@
   padding-top: 0.5em;
 }
 .peertube-server-hint {
-  z-index: 1;
+  z-index: 3;
   position: absolute;
   margin: 10px;
   padding: 5px 7px;

--- a/components/share/index.css
+++ b/components/share/index.css
@@ -738,7 +738,7 @@
   padding: 5px 7px;
   border-radius: 4px;
   font-family: monospace;
-  font-size: 0.9em;
+  font-size: 0.8em;
   background: #000000bb;
   color: #fff;
 }

--- a/components/share/index.css
+++ b/components/share/index.css
@@ -731,6 +731,31 @@
   font-weight: 100;
   padding-top: 0.5em;
 }
+.peertube-server-hint {
+  z-index: 1;
+  position: absolute;
+  margin: 10px;
+  padding: 5px 7px;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.9em;
+  background: #000000bb;
+  color: #fff;
+}
+.peertube-server-hint i.fa {
+  font-size: 0.8em;
+  margin-top: 1px;
+  margin-right: 5px;
+}
+.peertube-server-hint a {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+.topvideosWrapper .peertube-server-hint {
+  bottom: 0;
+  font-size: 0.6em;
+}
 .sharedate .selectDateTableWrapper {
   width: 500px;
 }

--- a/components/share/index.less
+++ b/components/share/index.less
@@ -960,7 +960,7 @@
 	padding: 5px 7px;
 	border-radius: 4px;
 	font-family: monospace;
-	font-size: 0.9em;
+	font-size: 0.8em;
 	background: #000000bb;
 	color: #fff;
 

--- a/components/share/index.less
+++ b/components/share/index.less
@@ -954,7 +954,7 @@
 }
 
 .peertube-server-hint {
-	z-index: 1;
+	z-index: 3;
 	position: absolute;
 	margin: 10px;
 	padding: 5px 7px;

--- a/components/share/index.less
+++ b/components/share/index.less
@@ -953,6 +953,35 @@
 	}
 }
 
+.peertube-server-hint {
+	z-index: 1;
+	position: absolute;
+	margin: 10px;
+	padding: 5px 7px;
+	border-radius: 4px;
+	font-family: monospace;
+	font-size: 0.9em;
+	background: #000000bb;
+	color: #fff;
+
+	i.fa {
+		font-size: 0.8em;
+		margin-top: 1px;
+		margin-right: 5px;
+	}
+
+	a {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+	}
+}
+
+.topvideosWrapper .peertube-server-hint {
+	bottom: 0;
+	font-size: 0.6em;
+}
+
 .sharedate{
 	.selectDateTableWrapper{
 		width : 500px;

--- a/components/share/templates/url.html
+++ b/components/share/templates/url.html
@@ -130,7 +130,7 @@
 
 				<% if(typeof video == 'undefined' || !video) { %> 
 					<div class="videoTips">
-						<div class="videoTip">
+						<div class="videoTip" style="<%- (app.platform.istest()) ? 'text-align: right' : '' %>" >
 							<span><%=e('expandvideo')%></span>
 						</div>
 					</div>

--- a/components/share/templates/url.html
+++ b/components/share/templates/url.html
@@ -49,6 +49,16 @@
 				</div>
 		
 			<% } else { %> 
+				<% if (app.platform.istest()) { %>
+					<% const videoLink = `https://${meta.host_name}/videos/embed/${meta.id}` %>
+
+					<div class="peertube-server-hint">
+						<a href="<%- videoLink %>">
+							<i class="fa fa-link"></i>
+							<span><%- meta.host_name %></span>
+						</a>
+					</div>
+				<% } %>
 				
 				<div class="js-player js-player-ini" data-plyr-provider="<%-meta.type%>" data-plyr-embed-id="<%-meta.url%>" data-plyr-video-id="<%-meta.id%>" data-plyr-host-name="<%-meta.host_name || ''%>">
 					

--- a/css/common.css
+++ b/css/common.css
@@ -264,6 +264,7 @@
   overflow: hidden;
 }
 .share_common .videoWrapper .videoTips {
+  z-index: 2;
   position: absolute;
   left: 0;
   right: 0;

--- a/css/common.less
+++ b/css/common.less
@@ -334,6 +334,7 @@
         overflow: hidden;
 
         .videoTips{
+            z-index: 2;
             position : absolute;
             left: 0;
             right: 0;


### PR DESCRIPTION
### What was done
There was no ability to look on which peertube server is video hosted. Sometimes, when we check the issues, we need to know this as fast as possible.

I made some UI changes into the player, that allows us to look this info from accounts added to test list.

_Related to pocketnetteam/bastyon-chat/pull/42_

<img src='https://user-images.githubusercontent.com/22795961/180952468-e76230ea-8965-401b-87cb-3f8c80dd2696.png' width='200'> <img src='https://user-images.githubusercontent.com/22795961/180952475-7228a5c9-bf37-42dd-a5cc-65f742b39fe2.png' width='200'>