### PR TITLE
fix: width limits for node address row

### DIFF
--- a/components/system16/index.css
+++ b/components/system16/index.css
@@ -599,9 +599,6 @@
                     padding-right: 0;
                 }*/
 }
-#system16 .nodescontent .node > div.name {
-  width: 120px;
-}
 #system16 .nodescontent .node > div.use {
   cursor: pointer;
 }

--- a/components/system16/index.less
+++ b/components/system16/index.less
@@ -793,10 +793,6 @@
                 text-overflow: ellipsis;
                 white-space: nowrap;
 
-                &.name{
-                    width: 120px;
-                }
-
                 &.use{
                     cursor: pointer;
     


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Node address row width no limited now inside `User settings > System`

## Other comments:
![Before](https://user-images.githubusercontent.com/22795961/193260153-88e1234e-213d-47db-a013-13b3f762cbcf.png)
![After](https://user-images.githubusercontent.com/22795961/193260157-6031c0fb-fbdf-465b-84d0-a2685d89fee0.png)
