### PR TITLE
workflow: downgrade from java 11 to java 8

### DIFF
--- a/.github/workflows/build.dev.yml
+++ b/.github/workflows/build.dev.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '8'
       - name: Check out Git repository
         uses: actions/checkout@v1
       - uses: actions/setup-node@v3

--- a/.github/workflows/deploy.pulls.dev.yml
+++ b/.github/workflows/deploy.pulls.dev.yml
@@ -249,7 +249,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '8'
       - uses: actions/setup-node@v3
         with:
           node-version: 14

--- a/.github/workflows/night.bastyon.com.yml
+++ b/.github/workflows/night.bastyon.com.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '8'
       - name: Check out Git repository
         uses: actions/checkout@v1
       - uses: actions/setup-node@v3

--- a/.github/workflows/night.test.bastyon.com.yml
+++ b/.github/workflows/night.test.bastyon.com.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '8'
       - name: Check out Git repository
         uses: actions/checkout@v1
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- This reverts commit 4fa8367

## Other comments:
Java 11 is crashing Github Actions. Currently, downgrading it...
