### PR TITLE
fix: macos errors on electron app quit

### DIFF
--- a/js/transports/proxified-fetch.js
+++ b/js/transports/proxified-fetch.js
@@ -40,9 +40,7 @@ function proxifiedFetchFactory(electronIpcRenderer) {
         if (init.signal) {
             fetchCancel = init.signal;
         }
-
-        console.log(init)
-
+        console.log(init);
         if (init.headers instanceof Headers) {
             init.headers.forEach((value, name) => {
                 preparedInit.headers[name] = value;
@@ -56,18 +54,12 @@ function proxifiedFetchFactory(electronIpcRenderer) {
                         fetchCancel.onabort = () => {
                             electronIpcRenderer.removeAllListeners(`ProxifiedFetch : InitialData[${id}]`);
                             electronIpcRenderer.removeAllListeners(`ProxifiedFetch : PartialResponse[${id}]`);
-
-                            console.log("abort", closed)
-
+                            console.log('abort', closed);
                             if (!closed) {
                                 electronIpcRenderer.send('ProxifiedFetch : Abort', id);
                                 controller.close();
                                 closed = true;
-
-                                
                             }
-
-                            
                         };
                     }
                     electronIpcRenderer.once(`ProxifiedFetch : Closed[${id}]`, (event) => {
@@ -79,19 +71,14 @@ function proxifiedFetchFactory(electronIpcRenderer) {
                         }
                     });
                     electronIpcRenderer.once(`ProxifiedFetch : Error[${id}]`, (event) => {
-
-
-                        console.log('event', event)
-
+                        console.log('event', event);
                         if (!closed) {
                             controller.error('PROXIFIED_FETCH_ERROR');
                             closed = true;
                             const err = new TypeError('Failed to fetch');
                             reject(err);
-
-                            return
+                            return;
                         }
-
                         reject(new DOMException('The user aborted a request.', 'AbortError'));
                     });
                     electronIpcRenderer.on(`ProxifiedFetch : PartialResponse[${id}]`, (event, data) => {
@@ -110,9 +97,7 @@ function proxifiedFetchFactory(electronIpcRenderer) {
                     });
                 }
             });
-
-            console.log('request:f', id)
-
+            console.log('request:f', id);
             electronIpcRenderer.on(`ProxifiedFetch : InitialData[${id}]`, (event, initialData) => {
                 const response = new Response(readStream, initialData);
                 Object.defineProperty(response, 'url', { value: url });
@@ -209,10 +194,16 @@ class ProxifiedFetchBridge {
         delete this.selfStatic;
     }
     answer(sender, event, id, data) {
+        if (!this.selfStatic) {
+            return;
+        }
         const eventName = `${this.selfStatic.eventGroup} : ${event}[${id}]`;
         sender.send(eventName, data);
     }
     listen(event, callback) {
+        if (!this.selfStatic) {
+            return;
+        }
         const eventName = `${this.selfStatic.eventGroup} : ${event}`;
         this.ipc.on(eventName, (...args) => {
             const arrangedArgs = args.slice(1);
@@ -221,6 +212,9 @@ class ProxifiedFetchBridge {
         });
     }
     listenOnce(event, callback) {
+        if (!this.selfStatic) {
+            return;
+        }
         const eventName = `${this.selfStatic.eventGroup} : ${event}`;
         this.ipc.once(eventName, (...args) => {
             const arrangedArgs = args.slice(1);
@@ -229,6 +223,9 @@ class ProxifiedFetchBridge {
         });
     }
     stopListen(event) {
+        if (!this.selfStatic) {
+            return;
+        }
         const eventName = `${this.selfStatic.eventGroup} : ${event}`;
         this.ipc.removeAllListeners(eventName);
     }

--- a/js/transports/proxified-fetch.ts
+++ b/js/transports/proxified-fetch.ts
@@ -57,6 +57,8 @@ export function proxifiedFetchFactory(electronIpcRenderer: Electron.IpcRenderer)
             fetchCancel = init.signal;
         }
 
+        console.log(init);
+
         if (init.headers instanceof Headers) {
             init.headers.forEach((value, name) => {
                 preparedInit.headers[name] = value;
@@ -72,6 +74,8 @@ export function proxifiedFetchFactory(electronIpcRenderer: Electron.IpcRenderer)
                         fetchCancel.onabort = () => {
                             electronIpcRenderer.removeAllListeners(`ProxifiedFetch : InitialData[${id}]`);
                             electronIpcRenderer.removeAllListeners(`ProxifiedFetch : PartialResponse[${id}]`);
+
+                            console.log('abort', closed);
 
                             if (!closed) {
                                 electronIpcRenderer.send('ProxifiedFetch : Abort', id);
@@ -93,7 +97,7 @@ export function proxifiedFetchFactory(electronIpcRenderer: Electron.IpcRenderer)
                     });
 
                     electronIpcRenderer.once(`ProxifiedFetch : Error[${id}]`, (event) => {
-                        console.log(event)
+                        console.log('event', event);
                         if (!closed) {
                             controller.error('PROXIFIED_FETCH_ERROR');
                             closed = true;
@@ -101,7 +105,7 @@ export function proxifiedFetchFactory(electronIpcRenderer: Electron.IpcRenderer)
                             const err = new TypeError('Failed to fetch');
                             reject(err);
 
-                            return
+                            return;
                         }
 
                         reject(new DOMException('The user aborted a request.', 'AbortError'));
@@ -125,6 +129,8 @@ export function proxifiedFetchFactory(electronIpcRenderer: Electron.IpcRenderer)
                     });
                 }
             });
+
+            console.log('request:f', id);
 
             electronIpcRenderer.on(`ProxifiedFetch : InitialData[${id}]`, (event, initialData) => {
                 const response = new Response(readStream, initialData);

--- a/js/transports/proxified-fetch.ts
+++ b/js/transports/proxified-fetch.ts
@@ -258,12 +258,20 @@ export class ProxifiedFetchBridge {
     }
 
     private answer(sender: Electron.WebContents, event: string, id: string, data?: any) {
+        if (!this.selfStatic) {
+            return;
+        }
+
         const eventName = `${this.selfStatic.eventGroup} : ${event}[${id}]`;
 
         sender.send(eventName, data);
     }
 
     private listen(event: string, callback: (...args) => void) {
+        if (!this.selfStatic) {
+            return;
+        }
+
         const eventName = `${this.selfStatic.eventGroup} : ${event}`;
 
         this.ipc.on(eventName, (...args) => {
@@ -275,6 +283,10 @@ export class ProxifiedFetchBridge {
     }
 
     private listenOnce(event: string, callback: (...args) => void) {
+        if (!this.selfStatic) {
+            return;
+        }
+
         const eventName = `${this.selfStatic.eventGroup} : ${event}`;
 
         this.ipc.once(eventName, (...args) => {
@@ -286,6 +298,10 @@ export class ProxifiedFetchBridge {
     }
 
     private stopListen(event: string) {
+        if (!this.selfStatic) {
+            return;
+        }
+
         const eventName = `${this.selfStatic.eventGroup} : ${event}`;
 
         this.ipc.removeAllListeners(eventName);

--- a/js/transports/tsconfig.json
+++ b/js/transports/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
* c96a4cc - add typescript config for **js/transports** sources
* b15fb3b - code missing in **proxified-fetch** sources fix
* e18af4a - macOS electron app produce errors on quit fix

## Other comments:
This PR fixes macOS Electron app issue. When user tries to quit the app from the menu, it produces errors related to **proxified-fetch** mechanism. Found and fixed.

<img width="600" src="https://user-images.githubusercontent.com/22795961/197198169-e0472426-6bb8-4a97-9045-4e54610e7ab7.png"/>
