### PR TITLE
fix: top menu not showing up in old browsers

### DIFF
--- a/components/menu/index.css
+++ b/components/menu/index.css
@@ -21,6 +21,7 @@
   left: 0;
   right: 0;
   top: 0;
+  min-height: 65px;
   height: calc(65px + var(--app-margin-top));
   padding-top: var(--app-margin-top);
   z-index: 20;

--- a/components/menu/index.less
+++ b/components/menu/index.less
@@ -31,6 +31,7 @@
 		left: 0;
 		right: 0;
 		top : 0;
+		min-height: 65px;
 		height: calc(65px + var(--app-margin-top));
 		padding-top: var(--app-margin-top);
 		z-index: 20;

--- a/css/main.css
+++ b/css/main.css
@@ -146,13 +146,12 @@
 }
 :root {
   --app-margin-top-default: 0px;
-  --app-margin-top: max(env(safe-area-inset-top), var(--app-margin-top-default));
+  --app-margin-top: 0px;
 }
-:root {
-  --safe-area-inset-top: 0px;
-  --safe-area-inset-right: 0px;
-  --safe-area-inset-bottom: 0px;
-  --safe-area-inset-left: 0px;
+@supports (width: max(1px, 1px)) {
+  :root {
+    --app-margin-top: max(env(safe-area-inset-top), var(--app-margin-top-default));
+  }
 }
 /* iOS 11.0: supports constant() css function. (Assume all other inset vars are supported.) */
 @supports (padding-top: constant(safe-area-inset-top)) {

--- a/css/main.less
+++ b/css/main.less
@@ -178,15 +178,14 @@
 }
 
 :root {
-	--app-margin-top-default: 0px;
-	--app-margin-top: max(env(safe-area-inset-top), var(--app-margin-top-default));
+    --app-margin-top-default: 0px;
+	--app-margin-top: 0px;
 }
 
-:root {
-	--safe-area-inset-top:      0px;
-	--safe-area-inset-right:    0px;
-	--safe-area-inset-bottom:   0px;
-	--safe-area-inset-left:     0px;
+@supports (width: max(1px, 1px)) {
+    :root {
+        --app-margin-top: max(env(safe-area-inset-top), var(--app-margin-top-default));
+    }
 }
 
 

--- a/css/main.less
+++ b/css/main.less
@@ -178,7 +178,7 @@
 }
 
 :root {
-    --app-margin-top-default: 0px;
+	--app-margin-top-default: 0px;
 	--app-margin-top: 0px;
 }
 


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- 6037f0b - Add fallback for CSS3 `max(...)` via `@supports`.
- 451edfd - Set `min-height: 65px` for case when `height` can't be calculated.

## Other comments:
All changes in this PR are related to `#menu .menuWrapper` element.

_This PR closes #741_