### PR TITLE
fix: recommendations load on post open

### DIFF
--- a/components/post/index.js
+++ b/components/post/index.js
@@ -1750,6 +1750,8 @@ var post = (function () {
 						self.closeContainer()
 					},
 
+					startload: true,
+
 					el : p.inWnd ? el.c.closest('.wndcontent') : null
 					
 				}, function(e, p){


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feat:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"

// TODO: Airbnb code style guide

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

Add a missing boolean to make the recommendations loading when post page is opened.

