### PR TITLE
fix: app prevents macos shutdown

### DIFF
--- a/tpls/main.js.tpl
+++ b/tpls/main.js.tpl
@@ -367,6 +367,10 @@ function initApp() {
 
     })
 
+    powerMonitor.on('shutdown', () => {
+        destroyAppSafe();
+    });
+
 }
 
 function createWindow() {

--- a/tpls/main.js.tpl
+++ b/tpls/main.js.tpl
@@ -5,7 +5,7 @@ if (global.WRITE_LOGS) {
 
 var open = require("open");
 
-const {protocol} = require('electron');
+const {protocol, powerMonitor} = require('electron');
 
 const ProxyInterface = require('./proxy16/ipc.js')
 const IpcBridge =require('./js/electron/ipcbridge.js')
@@ -354,8 +354,6 @@ function initApp() {
             autoUpdater.checkForUpdates();
         }, 10 * 60 * 1000);
     }
-
-    const { powerMonitor } = require('electron')
 
     powerMonitor.on('suspend', () => {
 


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Move powerMonitor require
- Add shutdown event listener