### PR TITLE
fix: Fix cordova mp4 fragment (no duration)

### DIFF
--- a/cordova/package.json
+++ b/cordova/package.json
@@ -55,6 +55,7 @@
     "cordova-plugin-camera-preview": "^0.12.3",
     "cordova-plugin-contacts-x": "file:cordova-plugin-contacts-x",
     "cordova-plugin-device": "^1.1.7",
+    "cordova-plugin-ffmpeg": "git+https://github.com/MaximBelov/cordova-plugin-ffmpeg.git",
     "cordova-plugin-file": "^7.0.0",
     "cordova-plugin-file-transfer": "file:cordova-plugin-file-transfer",
     "cordova-plugin-firebasex": "^14.2.1",
@@ -156,7 +157,8 @@
       "cordova-plugin-camera-preview": {},
       "cordova-plugin-audioinput": {},
       "cordova-plugin-actionsheet": {},
-      "cordova-plugin-background-mode": {}
+      "cordova-plugin-background-mode": {},
+      "cordova-plugin-ffmpeg": {}
     },
     "platforms": [
       "ios",

--- a/js/satolist.js
+++ b/js/satolist.js
@@ -7774,6 +7774,20 @@ Platform = function (app, listofnodes) {
 
                                                                 targetFile.internalURL = entry.toURL();
 
+                                                                // Use ffmpeg to fix the MP4 fragment file
+                                                                console.log("Fix video: " + targetFile.nativeURL.replace('file://',''));
+                                                                ffmpeg.exec("-i " + targetFile.nativeURL.replace('file://','') + " -c copy " + dirEntry4.nativeURL.replace('file://','') + "temp.mp4", (success) => {
+                                                                    dirEntry4.getFile("temp.mp4", {}, function(tempFileEntry) {
+                                                                        tempFileEntry.moveTo(dirEntry4, targetFile.name, function(success2) {
+                                                                            console.log("Video replaced !");
+                                                                        }, function(err) {
+                                                                            console.log("MoveTo Error: ", err);
+                                                                        });
+                                                                    });
+                                                                }, (failure) => {
+                                                                    console.log("Fix video fail: ", failure)
+                                                                });
+
                                                                 result.video = targetFile;
                                                                 result.size = fileDetails.size || null;
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

The mp4 fragments generated by Peertube do not have a duration, thus, when played through videojs, the time displayed is not correct.
This PR uses ffmpeg to remux the mp4 fragment into a valid mp4 that plays correctly in the video player.