### PR TITLE
fix: auth broken by notifications

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -87,7 +87,13 @@ Notifications = function(app) {
                 return resolve(Notification.permission);
             // If user didn't answer permission, ask him
             if (Notification.permission !== "denied") {
-                Notification.requestPermission().then(function (permission) {
+                const notificationPermission = Notification.requestPermission();
+
+                if (!notificationPermission) {
+                    return reject(Notification.permission);
+                }
+
+                notificationPermission.then(function (permission) {
                     // If the user accepts, let's create a notification
                     if (permission === "granted")
                         return resolve(permission);

--- a/js/satolist.js
+++ b/js/satolist.js
@@ -25102,7 +25102,13 @@ Platform = function (app, listofnodes) {
 
                 }
                 else{
-                    Notification.requestPermission().then((permission) => {
+                    const notificationPermission = Notification.requestPermission();
+
+                    if (!notificationPermission) {
+                        return Notification.permission;
+                    }
+
+                    notificationPermission.then((permission) => {
                         if (permission === 'granted') {
                             console.log('Notification permission granted.');
                             self.get(clbk)


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Add check for `undefined` returned by `Notification.requestPermission()`.

## Other comments:
The issue was found on latest DuckDuckGo browser. When try to authenticate, it's loading infinitely. If I reload the page it shows as authorized, however there are signs of something went wrong.

![error demo](https://user-images.githubusercontent.com/22795961/205490265-fdd22980-3634-4214-a7e6-dfaa0d0bbf3b.png)