### PR TITLE
fix: user-agent is not string in logs

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1283,7 +1283,7 @@ Application = function(p)
 
   self.Logger = new FrontendLogger(
     navigator.userAgent,
-    navigator.userAgentData,
+    JSON.stringify(navigator.userAgentData),
     location.href,
     Intl.DateTimeFormat().resolvedOptions().timeZone,
     self


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable, and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Fix missed `JSON.stringify(...)` in #762.
