### PR TITLE
feat: modal windows esc exit

### DIFF
--- a/components/lenta/index.js
+++ b/components/lenta/index.js
@@ -22,6 +22,8 @@ var lenta = (function(){
 		var subloaded = false
 		var subloadedindex = 0
 
+		var wasFullscreen = false;
+
 		var boosted = [],
 			boostloadedblock = 0,
 			boostplaces = {}
@@ -2255,8 +2257,11 @@ var lenta = (function(){
 				_.each(willshowed, function(share){
 					actions.shareReturnAfterOptimization(share)
 				})
-			}
+			},
 
+			changeFullscreenState : function () {
+				wasFullscreen = !!document.fullscreenElement;
+			},
 		}
 
 		var events = {
@@ -2751,16 +2756,41 @@ var lenta = (function(){
 			exitFullScreenVideo : function(){
 				var shareId = $(this).closest('.share').attr('id');
 
-					actions.exitFullScreenVideo(shareId)
+				document.removeEventListener('keyup', events.escKeyListener);
+				document.removeEventListener('fullscreenchange', events.fullscreenStateChange);
+
+				wasFullscreen = false;
+
+				actions.exitFullScreenVideo(shareId)
 			},
 
 			fullScreenVideo : function(){
 
 				var shareId = $(this).closest('.share').attr('id');
 
-					self.app.mobile.vibration.small()
+				document.addEventListener('keyup', (e) => {
+					events.escKeyListener(e, shareId);
+				});
+				document.addEventListener('fullscreenchange', events.fullscreenStateChange);
+
+				self.app.mobile.vibration.small()
 
 				actions.fullScreenVideo(shareId)
+			},
+
+			fullscreenStateChange : function () {
+				actions.changeFullscreenState();
+			},
+
+			escKeyListener : function (e, shareId) {
+				if (e.code === 'Escape' && !wasFullscreen) {
+					document.removeEventListener('keyup', events.escKeyListener);
+					document.removeEventListener('fullscreenchange', events.fullscreenStateChange);
+
+					wasFullscreen = false;
+
+					actions.exitFullScreenVideo(shareId);
+				}
 			},
 
 			opensvi : function(){

--- a/js/functions.js
+++ b/js/functions.js
@@ -582,10 +582,32 @@
 				else{	
 					el.append(wnd);
 				}
-				
+
+				let wasFullscreen = false;
+
+				const fullscreenStateListener = function () {
+					wasFullscreen = !!document.fullscreenElement;
+				};
+
+				const escListener = function (e) {
+					const isEsc = e.code === 'Escape';
+
+					if (isEsc && !wasFullscreen) {
+						actions['close'](true);
+						document.removeEventListener('keyup', escListener);
+						document.removeEventListener('fullscreenchange', fullscreenStateListener);
+						wasFullscreen = false;
+					}
+				};
+
+				document.addEventListener('keyup', escListener);
+				document.addEventListener('fullscreenchange', fullscreenStateListener);
 
 				wnd.find("._close").on('click', function(){
 					actions["close"](true);
+					document.removeEventListener('keyup', escListener);
+					document.removeEventListener('fullscreenchange', fullscreenStateListener);
+					wasFullscreen = false;
 				});
 
 				wnd.find("._expand").on('click', function(){

--- a/js/functions.js
+++ b/js/functions.js
@@ -1151,6 +1151,18 @@
 			el.on('click', function(){
 				self.destroy()
 			})
+
+			const escListener = function (e) {
+				const isEsc = e.code === 'Escape';
+
+				if (isEsc) {
+					self.destroy();
+					document.removeEventListener('keyup', escListener);
+				}
+			};
+
+			document.addEventListener('keyup', escListener);
+
 		}
 
 		var self = new dialog(p);


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- d51e4c9 - Wnd modals esc exit support (90% of all modals are of wnd class)
- d51e4c9 - Language panel esc exit support
- 450b317 - Lenta post esc exit support

## Other comments:
Modal windows are closing by esc key