### PR TITLE
repo: workflows use node 16 everywhere

### DIFF
--- a/.github/workflows/build.dev.yml
+++ b/.github/workflows/build.dev.yml
@@ -11,9 +11,9 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v1
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           npm i
@@ -48,9 +48,9 @@ jobs:
       - name: Save HEAD information
         run: git --no-pager log --decorate=short --pretty=oneline -n1 > head.txt
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           apt update && apt install -y binutils rpm
@@ -76,9 +76,9 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v1
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           npm i
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v1
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Install Cordova
         run: |
           npm i -g cordova@10

--- a/.github/workflows/build.release.yml
+++ b/.github/workflows/build.release.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install Linux dependencies
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/deploy.pulls.dev.yml
+++ b/.github/workflows/deploy.pulls.dev.yml
@@ -43,6 +43,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: repo.tgz
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Prepare
         run: |
           tar xzf repo.tgz
@@ -60,6 +64,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: repo.tgz
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Prepare
         run: |
           tar xzf repo.tgz
@@ -149,9 +157,9 @@ jobs:
       - name: Unpack artifact
         run: tar xzf repo.tgz
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           npm i
@@ -189,9 +197,9 @@ jobs:
       - name: Unpack artifact
         run: tar xzf repo.tgz
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           apt update && apt install -y binutils rpm
@@ -221,9 +229,9 @@ jobs:
       - name: Unpack artifact
         run: tar xzf repo.tgz
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           npm i
@@ -252,9 +260,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - uses: actions/setup-node@v3
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Install Cordova
         run: |
           npm i -g cordova@10

--- a/.github/workflows/night.bastyon.com.yml
+++ b/.github/workflows/night.bastyon.com.yml
@@ -13,7 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
       - name: Prepare
@@ -34,9 +35,9 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v1
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           npm i
@@ -71,9 +72,9 @@ jobs:
       - name: Save HEAD information
         run: git --no-pager log --decorate=short --pretty=oneline -n1 > head.txt
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           apt update && apt install -y binutils rpm
@@ -99,9 +100,9 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v1
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           npm i
@@ -125,9 +126,10 @@ jobs:
           java-version: '11'
       - name: Check out Git repository
         uses: actions/checkout@v1
-      - uses: actions/setup-node@v3
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Install Cordova
         run: |
           npm i -g cordova@10

--- a/.github/workflows/night.test.bastyon.com.yml
+++ b/.github/workflows/night.test.bastyon.com.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: gui
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
       - name: Prepare
@@ -33,9 +34,9 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v1
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           npm i
@@ -70,9 +71,9 @@ jobs:
       - name: Save HEAD information
         run: git --no-pager log --decorate=short --pretty=oneline -n1 > head.txt
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           apt update && apt install -y binutils rpm
@@ -98,9 +99,9 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v1
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Prepare building
         run: |
           npm i
@@ -124,9 +125,10 @@ jobs:
           java-version: '11'
       - name: Check out Git repository
         uses: actions/checkout@v1
-      - uses: actions/setup-node@v3
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Install Cordova
         run: |
           npm i -g cordova@10

--- a/.github/workflows/pre.pocketnet.app.yml
+++ b/.github/workflows/pre.pocketnet.app.yml
@@ -10,7 +10,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
 

--- a/.github/workflows/test.pocketnet.app.yml
+++ b/.github/workflows/test.pocketnet.app.yml
@@ -10,9 +10,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
 
       - name: Prepare
         run: |


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [ ] The workflow changes are stable, and I have tested them myself on the fork repository, to the best of my abilities.

## Changes:
- Update `actions/setup-node` to v3
- Use node 16 everywhere

## Other comments:
This PR is related to #873. Node 16 is mandatory for `node-gyp` to compile binary `raw-socket` node module.