### PR TITLE
patch: hide upload buttons when posting an audio file

### DIFF
--- a/components/share/index.js
+++ b/components/share/index.js
@@ -1635,6 +1635,26 @@ var share = (function(){
 						el.selectTime = el.c.find('.selectedTimeWrapper')
 						el.post = el.c.find('.post')
 						el.times = el.c.find('.panel .times')
+						el.uploadButtons = el.c.find('.postpanel .panelWrapper div[elementsid]')
+
+						// Function to show/hide the upload buttons
+						let setUploadButtons = function(buttons, show) {
+							if (!buttons || buttons.length <= 0) return;
+							for (let i = 0; i < buttons.length; i++) {
+								let attribute = buttons[i].getAttribute('elementsid');
+								if (attribute && attribute != 'stimes' && show == false)
+									buttons[i].style.display = 'none';
+								else
+									buttons[i].style.display = 'block';
+							}
+						}
+						// If uploading an audio file, remove all the other upload buttons
+						// But leave the "clear post" button
+						if (currentShare && currentShare.itisaudio())
+							setUploadButtons(el.uploadButtons, false);
+						// Else, show all the upload buttons
+						else
+							setUploadButtons(el.uploadButtons, true);
 
 						el.changePostTime.on('change', events.changePostTime)
 						el.selectTime.on('click', events.selectTime)

--- a/components/share/templates/postline.html
+++ b/components/share/templates/postline.html
@@ -31,7 +31,7 @@
 
                         <% if (window.testpocketnet == true) { %>
                         <div elementsid="peertubeAddAudio" class="item peertube tooltip nowidth" embeding="addAudio" title="<%=e('peertubeAddAudio')%>">
-                            <i class="fas fa-volume-up"></i>
+                            <i class="fas fa-volume-up"></i> <span class="mobiledevice"><%=e('peertubeAddAudio')%></span>
                         </div>
                         <% } %>
 


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feat:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"

// TODO: Airbnb code style guide

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

After uploading an audio file, all the upload buttons will be hidden.
If the audio file is removed or if the post is cleared, the upload buttons will be shown again.
This change is to avoid mixing multiple types (audio / video) inside the same post.

