### PR TITLE
feat: show built version badge sha

### DIFF
--- a/.github/actions/build.macos.yml
+++ b/.github/actions/build.macos.yml
@@ -12,7 +12,7 @@ runs:
     - name: Prepare building
       run: |
         npm i
-        npm run dev:bastyon
+        npm run dev:bastyon -- --sha=${{ steps.vars.outputs.sha_short }}
     - name: Prepare for app notarization
       run: |
         mkdir -p ~/private_keys/

--- a/.github/workflows/build.dev.yml
+++ b/.github/workflows/build.dev.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run dev:bastyon
+          npm run dev:bastyon -- -sha=${{ github.sha }}
       - name: Prepare for app notarization
         run: |
           mkdir -p ~/private_keys/
@@ -55,7 +55,7 @@ jobs:
         run: |
           apt update && apt install -y binutils rpm
           npm i
-          npm run dev:bastyon
+          npm run dev:bastyon -- -sha=${{ github.sha }}
       - name: Building
         run: |
           npm run distl
@@ -82,7 +82,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run dev:bastyon
+          npm run dev:bastyon -- -sha=${{ github.sha }}
       - name: Building
         run: |
           npm run dist
@@ -112,7 +112,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run minimize:cordova
+          npm run minimize:cordova -- -sha=${{ github.sha }}
           cd ./cordova
           npm i
       - name: Prepare configuration

--- a/.github/workflows/deploy.pulls.dev.yml
+++ b/.github/workflows/deploy.pulls.dev.yml
@@ -53,7 +53,7 @@ jobs:
           tar xzf repo.tgz
           rm -rf repo.tgz
           npm i
-          npm run minimize:bastyon -- -sha=${{ github.sha }}
+          npm run minimize:bastyon -- -sha=${{ github.sha }} --run=${{ github.run_id }}
       - name: Copy to dest dir
         run: rsync -ah --exclude={'.git','.gitignore','.github','package.json','package-lock.json','minimize.json','node_modules','.well-known','assets','proxy16','cordova','res','build'} ./ /docker/pre/
 
@@ -74,7 +74,7 @@ jobs:
           tar xzf repo.tgz
           rm -rf repo.tgz
           npm i
-          npm run minimize:bastyon:test -- -sha=${{ github.sha }}
+          npm run minimize:bastyon:test -- -sha=${{ github.sha }} --run=${{ github.run_id }}
       - name: Copy to dest dir
         run: rsync -ah --exclude={'.git','.gitignore','.github','package.json','package-lock.json','minimize.json','node_modules','.well-known','assets','proxy16','cordova','res','build'} ./ /docker/gui/
 
@@ -164,7 +164,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run dev:bastyon -- -sha=${{ github.sha }}
+          npm run dev:bastyon -- -sha=${{ github.sha }} --run=${{ github.run_id }}
       - name: Prepare for app notarization
         run: |
           mkdir -p ~/private_keys/
@@ -205,7 +205,7 @@ jobs:
         run: |
           apt update && apt install -y binutils rpm
           npm i
-          npm run dev:bastyon -- -sha=${{ github.sha }}
+          npm run dev:bastyon -- -sha=${{ github.sha }} --run=${{ github.run_id }}
       - name: Building
         run: |
           npm run distl
@@ -236,7 +236,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run dev:bastyon -- -sha=${{ github.sha }}
+          npm run dev:bastyon -- -sha=${{ github.sha }} --run=${{ github.run_id }}
       - name: Building
         run: |
           npm run dist
@@ -272,7 +272,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run minimize:cordova -- -sha=${{ github.sha }}
+          npm run minimize:cordova -- -sha=${{ github.sha }} --run=${{ github.run_id }}
           cd ./cordova
           npm i
       - name: Prepare configuration

--- a/.github/workflows/deploy.pulls.dev.yml
+++ b/.github/workflows/deploy.pulls.dev.yml
@@ -53,7 +53,7 @@ jobs:
           tar xzf repo.tgz
           rm -rf repo.tgz
           npm i
-          npm run minimize:bastyon
+          npm run minimize:bastyon -- -sha=${{ github.sha }}
       - name: Copy to dest dir
         run: rsync -ah --exclude={'.git','.gitignore','.github','package.json','package-lock.json','minimize.json','node_modules','.well-known','assets','proxy16','cordova','res','build'} ./ /docker/pre/
 
@@ -74,7 +74,7 @@ jobs:
           tar xzf repo.tgz
           rm -rf repo.tgz
           npm i
-          npm run minimize:bastyon:test
+          npm run minimize:bastyon:test -- -sha=${{ github.sha }}
       - name: Copy to dest dir
         run: rsync -ah --exclude={'.git','.gitignore','.github','package.json','package-lock.json','minimize.json','node_modules','.well-known','assets','proxy16','cordova','res','build'} ./ /docker/gui/
 
@@ -164,7 +164,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run dev:bastyon
+          npm run dev:bastyon -- -sha=${{ github.sha }}
       - name: Prepare for app notarization
         run: |
           mkdir -p ~/private_keys/
@@ -205,7 +205,7 @@ jobs:
         run: |
           apt update && apt install -y binutils rpm
           npm i
-          npm run dev:bastyon
+          npm run dev:bastyon -- -sha=${{ github.sha }}
       - name: Building
         run: |
           npm run distl
@@ -236,7 +236,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run dev:bastyon
+          npm run dev:bastyon -- -sha=${{ github.sha }}
       - name: Building
         run: |
           npm run dist
@@ -272,7 +272,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run minimize:cordova
+          npm run minimize:cordova -- -sha=${{ github.sha }}
           cd ./cordova
           npm i
       - name: Prepare configuration

--- a/.github/workflows/deploy.web.yml
+++ b/.github/workflows/deploy.web.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Prepare
         run: |
           npm i
-          npm run minimize:bastyon
+          npm run minimize:bastyon -- -sha=${{ github.sha }}
         
       - name: Prepare archive
         run: |

--- a/.github/workflows/night.bastyon.com.yml
+++ b/.github/workflows/night.bastyon.com.yml
@@ -51,7 +51,7 @@ jobs:
           tar xzf repo.tgz
           rm -rf repo.tgz
           npm i
-          npm run minimize:bastyon
+          npm run minimize:bastyon -- -sha=${{ github.sha }}
       - name: Copy to dest dir
         run: rsync -ah --exclude={'.git','.gitignore','.github','package.json','package-lock.json','minimize.json','node_modules','.well-known','assets','proxy16','cordova','res','build'} ./ /docker/night/
       - name: Reset nginx cache
@@ -77,7 +77,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run dev:bastyon
+          npm run dev:bastyon -- -sha=${{ github.sha }}
       - name: Prepare for app notarization
         run: |
           mkdir -p ~/private_keys/
@@ -118,7 +118,7 @@ jobs:
         run: |
           apt update && apt install -y binutils rpm
           npm i
-          npm run dev:bastyon
+          npm run dev:bastyon -- -sha=${{ github.sha }}
       - name: Building
         run: |
           npm run distl
@@ -149,7 +149,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run dev:bastyon
+          npm run dev:bastyon -- -sha=${{ github.sha }}
       - name: Building
         run: |
           npm run dist
@@ -185,7 +185,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run minimize:cordova
+          npm run minimize:cordova -- -sha=${{ github.sha }}
           cd ./cordova
           npm i
       - name: Prepare configuration

--- a/.github/workflows/night.test.bastyon.com.yml
+++ b/.github/workflows/night.test.bastyon.com.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Prepare
         run: |
           npm i
-          npm run minimize:bastyon:test
+          npm run minimize:bastyon:test -- -sha=${{ github.sha }}
       - name: Copy to dest dir
         run: rsync -ah --exclude={'.git','.gitignore','.github','package.json','package-lock.json','minimize.json','node_modules','.well-known','assets','proxy16','cordova','res','build'} ./ /docker/night.test/
       - name: Reset nginx cache
@@ -41,7 +41,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run dev:bastyon:test
+          npm run dev:bastyon:test -- -sha=${{ github.sha }}
       - name: Prepare for app notarization
         run: |
           mkdir -p ~/private_keys/
@@ -79,7 +79,7 @@ jobs:
         run: |
           apt update && apt install -y binutils rpm
           npm i
-          npm run dev:bastyon:test
+          npm run dev:bastyon:test -- -sha=${{ github.sha }}
       - name: Building
         run: |
           npm run distl
@@ -106,7 +106,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run dev:bastyon:test
+          npm run dev:bastyon:test -- -sha=${{ github.sha }}
       - name: Building
         run: |
           npm run dist
@@ -137,7 +137,7 @@ jobs:
       - name: Prepare building
         run: |
           npm i
-          npm run minimize:cordova:test
+          npm run minimize:cordova:test -- -sha=${{ github.sha }}
           cd ./cordova
           npm i
       - name: Prepare configuration

--- a/.github/workflows/pre.pocketnet.app.yml
+++ b/.github/workflows/pre.pocketnet.app.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Prepare
         run: |
           npm i
-          npm run minimize:bastyon
+          npm run minimize:bastyon -- -sha=${{ github.sha }}
 
       - name: Copy to dest dir
         run: rsync -ah --exclude={'.git','.gitignore','.github','package.json','package-lock.json','minimize.json','node_modules','.well-known','assets','proxy16','cordova','res','build'} ./ /docker/pre/

--- a/.github/workflows/test.pocketnet.app.yml
+++ b/.github/workflows/test.pocketnet.app.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Prepare
         run: |
           npm i
-          npm run minimize:bastyon:test
+          npm run minimize:bastyon:test -- -sha=${{ github.sha }}
 
       - name: Copy to dest dir
         run: rsync -ah --exclude={'.git','.gitignore','.github','package.json','package-lock.json','minimize.json','node_modules','.well-known','assets','proxy16','cordova','res','build'} ./ /docker/gui/

--- a/components/leftpanel/index.css
+++ b/components/leftpanel/index.css
@@ -243,6 +243,7 @@
   background: rgba(var(--color-txt-gray-dark), 0.1);
   color: rgba(var(--text-on-main-bg-color), 0.7);
   border-radius: 2px;
+  cursor: pointer;
 }
 #leftpanel .vc_valuecustom {
   font-size: 1.5em;

--- a/components/leftpanel/index.css
+++ b/components/leftpanel/index.css
@@ -214,18 +214,35 @@
 #leftpanel .rightbottomnav .copyright {
   display: flex;
   justify-content: flex-start;
-  align-items: center;
   margin-top: 2em;
 }
-#leftpanel .rightbottomnav .copyright .copy_logo {
+#leftpanel .rightbottomnav .copyright .app-logo {
   width: 14px;
   height: 14px;
+  margin-top: 3px;
+  background-image: url('../../img/logotypes/bastyon_logo_black.svg');
+  background-size: cover;
+  background-repeat: no-repeat;
+  filter: grayscale(1) brightness(1.8) contrast(0.5);
 }
-#leftpanel .rightbottomnav .copyright img {
-  opacity: 0.5;
-}
-#leftpanel .rightbottomnav .copyright .copyright_text {
+#leftpanel .rightbottomnav .copyright .text {
   margin-left: 0.5em;
+}
+#leftpanel .rightbottomnav .copyright .app-name,
+#leftpanel .rightbottomnav .copyright .app-version,
+#leftpanel .rightbottomnav .copyright .app-builtfrom {
+  display: inline-block;
+}
+#leftpanel .rightbottomnav .copyright .app-builtfrom {
+  position: absolute;
+  margin-left: 5px;
+  padding: 2px 5px;
+  font-family: Consolas, "courier new";
+  font-weight: bold;
+  line-height: 1;
+  background: rgba(var(--color-txt-gray-dark), 0.1);
+  color: rgba(var(--text-on-main-bg-color), 0.7);
+  border-radius: 2px;
 }
 #leftpanel .vc_valuecustom {
   font-size: 1.5em;

--- a/components/leftpanel/index.js
+++ b/components/leftpanel/index.js
@@ -211,6 +211,11 @@ var leftpanel = (function(){
 						})
 					})
 
+					_p.el.find('.app-builtfrom').on('click', () => {
+						navigator.clipboard.writeText(`${packageversion}-${builtfromsha}`);
+						sitemessage(self.app.localization.e('copybuiltfrom'));
+					});
+
 					if(clbk) clbk()
 				})
 			},

--- a/components/leftpanel/index.less
+++ b/components/leftpanel/index.less
@@ -299,20 +299,38 @@
 		.copyright {
 			display: flex;
 			justify-content: flex-start;
-			align-items: center;
 			margin-top: 4 * @rhythm;
 
-			.copy_logo {
+			.app-logo {
 				width: 14px;
 				height: 14px;
+				margin-top: 3px;
+				background-image: url('../../img/logotypes/bastyon_logo_black.svg');
+				background-size: cover;
+				background-repeat: no-repeat;
+				filter: grayscale(1) brightness(1.8) contrast(0.5);
 			}
 
-			img{
-				opacity: 0.5;
-			}
-
-			.copyright_text {
+			.text {
 				margin-left: @rhythm;
+			}
+
+			.app-name,
+			.app-version,
+			.app-builtfrom {
+				display: inline-block;
+			}
+
+			.app-builtfrom {
+				position: absolute;
+				margin-left: 5px;
+				padding: 2px 5px;
+				font-family: Consolas, "courier new";
+				font-weight: bold;
+				line-height: 1;
+				background: rgba(var(--color-txt-gray-dark), 0.1);
+				color: rgba(var(--text-on-main-bg-color), 0.7);
+				border-radius: 2px;
 			}
 		}
 	}

--- a/components/leftpanel/index.less
+++ b/components/leftpanel/index.less
@@ -331,6 +331,7 @@
 				background: rgba(var(--color-txt-gray-dark), 0.1);
 				color: rgba(var(--text-on-main-bg-color), 0.7);
 				border-radius: 2px;
+				cursor: pointer;
 			}
 		}
 	}

--- a/components/leftpanel/templates/footer.html
+++ b/components/leftpanel/templates/footer.html
@@ -31,7 +31,16 @@
     <% var year = new Date().getFullYear() %>
 
     <div class="copyright">
-        <img class="copy_logo" src="img/logogray.png" alt="logo">
-        <span class="copyright_text"><%-app.meta.fullname%> <% if(window.packageversion) {%> <%-window.packageversion%><% } %>, 2019&mdash;<%-year%></span>
+        <div class="app-logo"></div>
+        <span class="text">
+            <div class="app-name"><%-app.meta.fullname%></div>
+            <% if (window.packageversion) { %>
+                <div class="app-version"><%-window.packageversion%></div>
+            <% } %>
+            <% if (window.builtfromsha) { %>
+                <div class="app-builtfrom"><%-window.builtfromsha%></div>
+            <% } %>
+            <div class="app-years">2019 &mdash; <%-year%></div>
+        </span>
     </div>
 </div>

--- a/components/userpage/index.css
+++ b/components/userpage/index.css
@@ -167,9 +167,6 @@
   padding-left: 1em;
   margin-left: 150px;
 }
-#userpage .maketsWrapper .contents {
-  padding-top: 2em;
-}
 #userpage .maketsWrapper .contents .added {
   text-align: right;
 }
@@ -220,6 +217,15 @@
 }
 #userpage .maketsWrapper .contents .applicationupdatemodule .applicaitonversion {
   cursor: pointer;
+}
+#userpage .maketsWrapper .contents .applicationupdatemodule .app-builtfrom {
+  padding: 2px 5px;
+  font-family: Consolas, "courier new";
+  font-weight: bold;
+  line-height: 1;
+  background: rgba(var(--color-txt-gray-dark), 0.1);
+  color: rgba(var(--text-on-main-bg-color), 0.7);
+  border-radius: 2px;
 }
 #userpage .maketsWrapper .contents .applicationupdatemodule .updatingprogress {
   display: none;

--- a/components/userpage/index.css
+++ b/components/userpage/index.css
@@ -226,6 +226,7 @@
   background: rgba(var(--color-txt-gray-dark), 0.1);
   color: rgba(var(--text-on-main-bg-color), 0.7);
   border-radius: 2px;
+  cursor: pointer;
 }
 #userpage .maketsWrapper .contents .applicationupdatemodule .updatingprogress {
   display: none;

--- a/components/userpage/index.js
+++ b/components/userpage/index.js
@@ -796,8 +796,11 @@ var userpage = (function(){
 							})
 						})
 
-	
-	
+						_p.el.find('.app-builtfrom').on('click', () => {
+							navigator.clipboard.writeText(`${packageversion}-${builtfromsha}`);
+							sitemessage(self.app.localization.e('copybuiltfrom'));
+						});
+
 						if (clbk)
 							clbk();
 					})

--- a/components/userpage/index.less
+++ b/components/userpage/index.less
@@ -292,6 +292,16 @@
 					cursor: pointer;
 				}
 
+				.app-builtfrom {
+					padding: 2px 5px;
+					font-family: Consolas, "courier new";
+					font-weight: bold;
+					line-height: 1;
+					background: rgba(var(--color-txt-gray-dark), 0.1);
+					color: rgba(var(--text-on-main-bg-color), 0.7);
+					border-radius: 2px;
+				}
+
 				.updatingprogress{
 					display: none;
 					position: absolute;

--- a/components/userpage/index.less
+++ b/components/userpage/index.less
@@ -300,6 +300,7 @@
 					background: rgba(var(--color-txt-gray-dark), 0.1);
 					color: rgba(var(--text-on-main-bg-color), 0.7);
 					border-radius: 2px;
+					cursor: pointer;
 				}
 
 				.updatingprogress{

--- a/components/userpage/templates/contents.html
+++ b/components/userpage/templates/contents.html
@@ -191,6 +191,11 @@
                             <%=e('applicationversion')%> &middot; <%- window.packageversion %>
                         </span>
                         
+                        <% if (window.builtfromsha) { %>
+                            &nbsp;&middot;&nbsp;
+                            <span class="app-builtfrom"><%- window.builtfromsha %></span>
+                        <% } %>
+
                     <% } %>
                     
                 </div>

--- a/localization/de.js
+++ b/localization/de.js
@@ -859,6 +859,8 @@ _l.desktopPopupDisagree = "Nicht jetzt"
 
 _l.profanity_tag = 'profanität'
 
+_l.copybuiltfrom = "Versammlungsnummer erfolgreich kopiert"
+
 _l.saved = "Gespeicherte"
 _l.savePost = "Beitrag speichern"
 _l.postsaved = "Beitrag gespeichert"

--- a/localization/en.js
+++ b/localization/en.js
@@ -1,4 +1,4 @@
-﻿var appname = ((window.projects_meta || {})[window.pocketnetproject || "Bastyon"] || {}).fullname || 'Bastyon'
+var appname = ((window.projects_meta || {})[window.pocketnetproject || "Bastyon"] || {}).fullname || 'Bastyon'
 
 
 console.log('window.projects_meta', window.projects_meta)
@@ -2517,9 +2517,9 @@ _l.goToDiagnose = "Go to Diagnostics";
 _l.connectingTo = "Connecting to";
 _l.earnings = "Total earnings";
 
+_l.copybuiltfrom = "Application build version copied"
 
-
-_l.endedCall = "Call ended",
+_l.endedCall = "Call ended"
 _l.incomingCall = "Incoming call"
 
 _l.authHeading = "Auth";

--- a/localization/es.js
+++ b/localization/es.js
@@ -854,6 +854,7 @@ _l.desktopPopupTitle = "Obtenga información sin censura en la aplicación de es
 _l.desktopPopupAgree = "Descargar la aplicación"
 _l.desktopPopupDisagree = "Ahora no"
 
+_l.copybuiltfrom = "Número de conjunto copiado"
 
 _l.profanity_tag = 'blasfemia'
 

--- a/localization/fr.js
+++ b/localization/fr.js
@@ -1381,6 +1381,8 @@ _l.desktopPopupDisagree = "Pas maintenant"
 
 _l.profanity_tag = 'impiété'
 
+_l.copybuiltfrom = "Numéro d'assemblage copié"
+
 _l.saved = "Sauvegardé"
 _l.savePost = "Sauvegarder le post"
 _l.postsaved = "Post sauvegardé"

--- a/localization/it.js
+++ b/localization/it.js
@@ -1219,6 +1219,8 @@ _l.desktopPopupTitle = "Ottieni informazioni non censurate nell'app desktop Bast
 _l.desktopPopupAgree = "Scarica l'app"
 _l.desktopPopupDisagree = "Non ora"
 
+_l.copybuiltfrom = "Numero di montaggio copiato"
+
 _l.profanity_tag = 'volgarità'
 
 _l.saved = "Salvati"

--- a/localization/kr.js
+++ b/localization/kr.js
@@ -856,6 +856,8 @@ _l.desktopPopupTitle = "Bastyon 데스크탑 앱에서 무수정 정보 가져�
 _l.desktopPopupAgree = "앱 다운로드"
 _l.desktopPopupDisagree = "지금은 아닙니다"
 
+_l.copybuiltfrom = "어셈블리 번호 복사 성공"
+
 _l.profanity_tag = '욕설'
 
 _l.saved = "저장됨"

--- a/localization/ru.js
+++ b/localization/ru.js
@@ -1,4 +1,4 @@
-﻿if(typeof loclib == "undefined" || !loclib)
+if(typeof loclib == "undefined" || !loclib)
 	loclib = {};
 
 	loclib.ru = {};
@@ -2304,6 +2304,8 @@ _l.goToDiagnose = "Перейти на страницу диагностики";
 _l.connectingTo = "Проверка";
 
 _l.earnings = "Всего заработано";
+
+_l.copybuiltfrom = "Номер сборки скопирован"
 
 _l.authHeading = "Авторизация";
 

--- a/localization/zh.js
+++ b/localization/zh.js
@@ -1026,6 +1026,7 @@ _l.desktopPopupTitle = "在 Bastyon 桌面应用程序中获取未经审查的�
 _l.desktopPopupAgree = "下载应用程序"
 _l.desktopPopupDisagree = "不是现在"
 
+_l.copybuiltfrom = "组装号被复制到剪贴板上"
 
 _l.profanity_tag = '褻瀆'
 

--- a/minimize.js
+++ b/minimize.js
@@ -113,6 +113,7 @@ var vars = {
 		store : args.store || false,
 		name : _meta[args.project].name,
 		sha : args.sha || false,
+		run : args.run || false,
 	},
 	prod : {
 		proxypath : '"https://pocketnet.app:8899/"',
@@ -124,6 +125,7 @@ var vars = {
 		store : args.store || false,
 		name : _meta[args.project].name,
 		sha : args.sha || false,
+		run : args.run || false,
 	}
 }
 
@@ -904,7 +906,13 @@ fs.exists(mapJsPath, function (exists) {
 								if (isHex.test(VARS.sha)) {
 									const shaShort = VARS.sha.slice(0, 7);
 
-									JSENV += '<script>window.builtfromsha = "' + shaShort + '";</script>\n';
+									let builtFrom = shaShort;
+
+									if (VARS.run) {
+										builtFrom += `-${VARS.run}`;
+									}
+
+									JSENV += '<script>window.builtfromsha = "' + builtFrom + '";</script>\n';
 								}
 							}
 

--- a/minimize.js
+++ b/minimize.js
@@ -111,7 +111,8 @@ var vars = {
 		path : args.path,
 		project : args.project,
 		store : args.store || false,
-		name : _meta[args.project].name
+		name : _meta[args.project].name,
+		sha : args.sha || false,
 	},
 	prod : {
 		proxypath : '"https://pocketnet.app:8899/"',
@@ -121,8 +122,8 @@ var vars = {
 		path : args.path,
 		project : args.project,
 		store : args.store || false,
-		name : _meta[args.project].name
-
+		name : _meta[args.project].name,
+		sha : args.sha || false,
 	}
 }
 
@@ -897,6 +898,16 @@ fs.exists(mapJsPath, function (exists) {
 								JSENV += '<script>window.pocketnetstore = ' + VARS.store + ';</script>\n';
 							}
 							
+							if(VARS.sha){
+								const isHex = /^[0-9A-Fa-f]+$/;
+
+								if (isHex.test(VARS.sha)) {
+									const shaShort = VARS.sha.slice(0, 7);
+
+									JSENV += '<script>window.builtfromsha = "' + shaShort + '";</script>\n';
+								}
+							}
+
 
 							JSENV += '<script>window.packageversion = "' + package.version + '";</script>\n';
 							JSENV += '<script>window.versionsuffix = "' + package.versionsuffix + '";</script>\n';


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- Add "built-from" badge for desktop UI
- Add "built-from" badge for mobile UI
- Support "copy on click"

## Extra changes:

- Refactor app info block
- Use vector logo with CSS3 filters applied

## Other comments:

- When built from PR assembly action run, badge would contain **`base_commit_sha`** + **`run_unique_numeric_id`**.
- When built from release action runs, badge would contain **`base_commit_sha`**.
- When built from local station, badge would not appear. To show it, pass **`-sha=base_commit_sha`** and optionally **`-run=run_unique_numeric_id`** flags.
- Copied value would have next format - **`app_version`**-**`base_commit_sha`**-**`run_unique_numeric_id`**

#### Demonstration of how it works
![Example of badge](https://user-images.githubusercontent.com/22795961/221892893-3a4f8bd5-fdcf-49c1-ad91-1bb086046f19.png)