### PR TITLE
patch: ipfs video links support and embed media player fixes

### DIFF
--- a/components/bestposts/index.js
+++ b/components/bestposts/index.js
@@ -116,7 +116,7 @@ var bestposts = (function(){
 					if(
 						url && !og && 
 
-						!(meta.type == 'youtube' || meta.type == 'vimeo' || meta.type == 'bitchute' || meta.type == 'peertube') && 
+						!(meta.type == 'youtube' || meta.type == 'vimeo' || meta.type == 'bitchute' || meta.type == 'peertube' || meta.type == 'ipfs') &&
 
 						!self.app.platform.sdk.usersettings.meta.preview.value
 					){

--- a/components/lenta/index.js
+++ b/components/lenta/index.js
@@ -4040,7 +4040,7 @@ var lenta = (function(){
 					if(
 						url && !og && 
 
-						!(meta.type == 'youtube' || meta.type == 'vimeo' || meta.type == 'bitchute' || meta.type == 'peertube') && 
+						!(meta.type == 'youtube' || meta.type == 'vimeo' || meta.type == 'bitchute' || meta.type == 'peertube' || meta.type == 'ipfs') &&
 
 						!self.app.platform.sdk.usersettings.meta.preview.value
 					){

--- a/components/post/index.js
+++ b/components/post/index.js
@@ -1727,7 +1727,8 @@ var post = (function () {
 							meta.type == 'youtube' ||
 							meta.type == 'vimeo' ||
 							meta.type == 'bitchute' ||
-							meta.type == 'peertube'
+							meta.type == 'peertube' ||
+							meta.type == 'ipfs'
 						) {
 							if (clbk) clbk();
 						} else {

--- a/components/share/index.js
+++ b/components/share/index.js
@@ -750,7 +750,7 @@ var share = (function(){
 
 
 				if(!currentShare.url.v){
-					var r = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%|_\+.~#/?&//=]*)?/gi; 
+					var r = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,5}\b(\/[-a-zA-Z0-9@:%|_\+.~#/?&//=]*)?/gi;
 					
 
 					var matches = text.match(r);
@@ -1983,7 +1983,7 @@ var share = (function(){
 
 					if(currentShare.url.v && !og){
 
-						if (meta.type == 'youtube' || meta.type == 'vimeo' || meta.type == 'bitchute' || meta.type == 'peertube') {
+						if (meta.type == 'youtube' || meta.type == 'vimeo' || meta.type == 'bitchute' || meta.type == 'peertube' || meta.type == 'ipfs') {
 
 							destroyPlayer()
 

--- a/components/share/index.js
+++ b/components/share/index.js
@@ -795,7 +795,7 @@ var share = (function(){
 								if(currentShare.url.v) return;
 
 								const ipfsIdRegex = /ipfs\/([A-z0-9]+)/;
-								const ipfsId = url.match(ipfsIdRegex)[1];
+								const ipfsId = url.match(ipfsIdRegex)?.[1];
 
 								if (ipfsId) {
 									const ipfsUrl = `https://ipfs.io/ipfs/${ipfsId}`;

--- a/components/share/index.js
+++ b/components/share/index.js
@@ -747,13 +747,8 @@ var share = (function(){
 			},
 
 			isIpfsVideo : async function(url) {
-				const abortControl = new AbortController();
-				const signal = abortControl.signal;
-
-				return fetch(url, { signal })
+				return fetch(url, { method: 'HEAD' })
 					.then((res) => {
-						abortControl.abort();
-
 						const contentType = res.headers.get('content-type');
 
 						const isMp4 = (contentType === 'video/mp4');

--- a/components/share/templates/url.html
+++ b/components/share/templates/url.html
@@ -11,7 +11,7 @@
 
 			var aspectRatio = Number((info.data || deep(localdata, 'infos.videoDetails') || {}).aspectRatio || 0);
 
-			var image = videoImage(url)
+			var image = info.data.image
 	%>
 		<div class="videoWrapper fullscreenActive <%- (aspectRatio < 1.25) && (aspectRatio >= 0.9) ? 'squareVideo' : ''%> <%- (aspectRatio < 0.9) && (aspectRatio != 0) ? 'verticalVideo' : ''%>" pid="<%- makeid() %>">
 			

--- a/components/share/templates/url.html
+++ b/components/share/templates/url.html
@@ -3,7 +3,7 @@
 
 	if(typeof share == 'undefined') share = {};
 
-	if((meta.type == 'youtube') || meta.type == 'vimeo' || meta.type == 'bitchute' || meta.type == 'peertube'){ 
+	if((meta.type == 'youtube') || meta.type == 'vimeo' || meta.type == 'bitchute' || meta.type == 'peertube' || meta.type == 'ipfs'){
 		
 
 			var info = app.platform.sdk.videos.storage[url] || app.platform.sdk.videos.storage[meta.id] || {}

--- a/components/socialshare2/index.js
+++ b/components/socialshare2/index.js
@@ -228,7 +228,7 @@ var socialshare2 = (function(){
 						if(share.url){
 							var meta = app.platform.parseUrl(share.url);
 
-							if((meta.type == 'youtube') || meta.type == 'vimeo' || meta.type == 'bitchute' || meta.type == 'peertube'){
+							if((meta.type == 'youtube') || meta.type == 'vimeo' || meta.type == 'bitchute' || meta.type == 'peertube' || meta.type == 'ipfs'){
 								s.push('fullscreenvideo')
 							}
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -10248,7 +10248,7 @@
 		}
 
 		if(v.type == 'vimeo'){
-			return 'https://i.vimeocdn.com/video/'+v.id+'_320.jpg'
+			return 'https://vumbnail.com/'+v.id+'.jpg'
 		}
 
 		if(v.type == 'peertube'){

--- a/js/functions.js
+++ b/js/functions.js
@@ -10352,8 +10352,9 @@
 		} else if (pathname.includes('/ipfs/')) {
 			const ipfsIdRegex = /ipfs\/([A-z0-9]+)/;
 			const ipfsId = path.match(ipfsIdRegex)[1];
+			const isVideo = (searchParams.get('type') === 'video');
 
-			if (!ipfsId) {
+			if (!ipfsId || !isVideo) {
 				return {};
 			}
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -10299,45 +10299,45 @@
 		}
 
 		const { hostname, pathname, searchParams } = new URL(url);
+		const path = pathname.slice(1);
+		const pathParts = path.split('/');
 
 		if (type === 'peertube') {
 			host_name = hostname;
 
-			if (pathname.includes('stream')) {
+			if (path.includes('stream')) {
 				subType = 'peertubeStream';
-				id = pathname.slice(1).split('/')[1];
+				id = pathParts[1];
 			} else {
 				subType = 'common';
-				id = pathname.slice(1);
+				id = path;
 			}
 		} else if (hostname.includes('youtube.com')) {
 			type = 'youtube';
 			url = `https://youtu.be/${id}`;
 
-			if (pathname.includes('watch')) {
+			if (path.includes('watch')) {
 				id = searchParams.get('v');
-			} else if (pathname.includes('shorts')) {
-				id = pathname.slice(1).split('/')[1];
+			} else if (path.includes('shorts')) {
+				id = pathParts[1];
 			}
 		} else if (hostname.includes('youtu.be')) {
 			type = 'youtube';
-			id = pathname.slice(1);
+			id = path;
 		} else if (hostname.includes('player.vimeo.com')) {
 			type = 'vimeo';
-			id = pathname.slice(1).split('/')[1];
+			id = pathParts[1];
 		} else if (hostname.includes('vimeo.com')) {
-			rawId = pathname.slice(1);
-
-			if (!isNaN(rawId)) {
+			if (!isNaN(path)) {
 				type = 'vimeo';
-				id = rawId;
+				id = path;
 			}
 		} else if (hostname.includes('bitchute.com')) {
 			type = 'bitchute';
-			id = pathname.slice(1).split('/')[1];
+			id = pathParts[1];
 		} else if (hostname.includes('brighteon.com')) {
 			type = 'brighteon';
-			id = pathname.slice(1);
+			id = path;
 		}
 
 		/* else if (hostname.includes('stream.brighteon.com')) {

--- a/js/functions.js
+++ b/js/functions.js
@@ -10284,63 +10284,70 @@
 	}
 
 	parseVideo = function(url) {
-		var _url = url;
+		if (!url) {
+			return {};
+		}
 
-	    var test = _url.match(/(peertube:\/\/)?(http:\/\/|https:\/\/|)?(player.|www.)?(pocketnetpeertube[0-9]*\.nohost\.me|peer\.tube|vimeo\.com|youtu(be\.com|\.be|be\.googleapis\.com)|bitchute\.com|brighteon\.com|stream\.brighteon\.com)\/((videos?\/|embed\/|watch\/?)*(\?v=|v\/)?)*([A-Za-z0-9._%-]*)(\&\S+)?/);
-	    var type = null
-		var id = null
-		var host_name = null
-		var subType = null
+		let id = null;
+		let type = null;
+		let host_name = null;
+		let subType = null;
 
-		if(_url && _url.indexOf('peertube://') > -1){
-			var ch = _url.replace('peertube://', '').split('/');
-			id = ch[1]
+		if (url.startsWith('peertube:')) {
 			type = 'peertube';
-			subType = _url.includes('/stream') ? 'peertubeStream' : 'common';
-			host_name = ch[0]
-
+			url = url.replace('peertube:', 'http:');
 		}
-		else{
-			if(test && test[2]){
 
-				if (test.indexOf('youtube.com') > -1 || test.indexOf('youtu.be') > -1) {
-					type = 'youtube'
-			        id = test[9]
-					url = 'https://youtu.be/' + id
-			    }
-				if (test.indexOf('vimeo.com') > -1) {
-					type = 'vimeo'
-                    id = test[9]
-			    }
-				if (test.indexOf('bitchute.com') > -1) {
-					type = 'bitchute'
-					id = test[9]
-			    }
-				if (test.indexOf('brighteon.com') > -1) {
-					type = 'brighteon'
-					id = test[9]
-				}
-				if (test.indexOf('stream.brighteon.com') > -1) {
-					type = 'stream.brighteon'
-					let tempUrl = url;
-					if (tempUrl.indexOf('/live/') != -1)
-						tempUrl = tempUrl.replace('/live/', '/embed/');
-					id = url.substring(url.lastIndexOf('/') + 1);
-				}
+		const { hostname, pathname, searchParams } = new URL(url);
 
+		if (type === 'peertube') {
+			host_name = hostname;
+
+			if (pathname.includes('stream')) {
+				subType = 'peertubeStream';
+				id = pathname.slice(1).split('/')[1];
+			} else {
+				subType = 'common';
+				id = pathname.slice(1);
 			}
+		} else if (hostname.includes('youtube.com')) {
+			type = 'youtube';
+			url = `https://youtu.be/${id}`;
+
+			if (pathname.includes('watch')) {
+				id = searchParams.get('v');
+			} else if (pathname.includes('shorts')) {
+				id = pathname.slice(1).split('/')[1];
+			}
+		} else if (hostname.includes('youtu.be')) {
+			type = 'youtube';
+			id = pathname.slice(1);
+		} else if (hostname.includes('player.vimeo.com')) {
+			type = 'vimeo';
+			id = pathname.slice(1).split('/')[1];
+		} else if (hostname.includes('vimeo.com')) {
+			rawId = pathname.slice(1);
+
+			if (!isNaN(rawId)) {
+				type = 'vimeo';
+				id = rawId;
+			}
+		} else if (hostname.includes('bitchute.com')) {
+			type = 'bitchute';
+			id = pathname.slice(1).split('/')[1];
+		} else if (hostname.includes('brighteon.com')) {
+			type = 'brighteon';
+			id = pathname.slice(1);
 		}
 
-	    // if(test && url.indexOf('channel') == -1 && url.indexOf("user") == -1){}
+		/* else if (hostname.includes('stream.brighteon.com')) {
+			type = 'brighteon';
+			id = pathname.slice(1);
+		}*/
 
-	    return {
-	        type: type,
-	        url : url,
-	        id : id,
-			host_name : host_name,
-			subType : subType,
-	    };
+		return { type, url, id, host_name, subType };
 	}
+
 	nl2br = function(str){
 		return str.replace(/\n/g, '<br/>');
 	}

--- a/js/functions.js
+++ b/js/functions.js
@@ -1949,6 +1949,12 @@
 
 				src = src.replace('bastyon.com:8092', 'pocketnet.app:8092').replace('test.pocketnet', 'pocketnet')
 				
+				if (src.includes('www.youtube.com')) {
+					const videoId = src.match(/\/(shorts|embed)\/(.*|)\?/)[2];
+
+					src = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
+				}
+
 				image.src = src
 				image.onload = () => {
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -10349,6 +10349,16 @@
 		} else if (hostname.includes('brighteon.com')) {
 			type = 'brighteon';
 			id = path;
+		} else if (pathname.includes('/ipfs/')) {
+			const ipfsIdRegex = /ipfs\/([A-z0-9]+)/;
+			const ipfsId = path.match(ipfsIdRegex)[1];
+
+			if (!ipfsId) {
+				return {};
+			}
+
+			type = 'ipfs';
+			id = ipfsId;
 		}
 
 		/* else if (hostname.includes('stream.brighteon.com')) {

--- a/js/functions.js
+++ b/js/functions.js
@@ -10298,7 +10298,18 @@
 			url = url.replace('peertube:', 'http:');
 		}
 
-		const { hostname, pathname, searchParams } = new URL(url);
+		let hostname, pathname, searchParams;
+
+		try {
+			const urlParts = new URL(url);
+
+			hostname = urlParts.hostname;
+			pathname = urlParts.pathname;
+			searchParams = urlParts.searchParams;
+		} catch (err) {
+			return {};
+		}
+
 		const path = pathname.slice(1);
 		const pathParts = path.split('/');
 

--- a/js/kit.js
+++ b/js/kit.js
@@ -1410,7 +1410,7 @@ Share = function(lang){
 
 		if(self.url.v && self.url.v.length && !self.itisvideo() && !self.itisaudio()){
 
-			var l = trim((trim(self.message.v) + trim(self.caption.v)).replace(self.url.v.length, '')).length
+			var l = trim((trim(self.message.v) + trim(self.caption.v)).replace(self.url.v, '')).length
 
 			if (l < 30 && !self.images.v.length){
 				return 'url'

--- a/js/satolist.js
+++ b/js/satolist.js
@@ -24841,7 +24841,20 @@ Platform = function (app, listofnodes) {
 
                     return Promise.all(promises)
 
-                }
+                },
+
+                ipfs : function(links) {
+                    const dataMap = links.map((l) => {
+                        l.data = {
+                            views : 0,
+                            image : null
+                        };
+
+                        return l;
+                    });
+
+                    return Promise.resolve(dataMap);
+                },
             },
 
             volume : 0,

--- a/js/vendor/plyr.js
+++ b/js/vendor/plyr.js
@@ -1376,6 +1376,10 @@ typeof navigator === "object" && (function (global, factory) {
       args[_key - 1] = arguments[_key];
     }
 
+    if (input.includes('/shorts/')) {
+      input.replace('/shorts/', '/embed/');
+    }
+
     if (is$1.empty(input)) {
       return input;
     }
@@ -4304,6 +4308,10 @@ typeof navigator === "object" && (function (global, factory) {
         (image.naturalWidth >= minWidth ? resolve : reject)(image);
       };
 
+      if (src?.includes?.('/shorts/')) {
+        src = src.replace('/shorts/', '/embed/');
+      }
+
       Object.assign(image, {
         onload: handler,
         onerror: handler,
@@ -6019,6 +6027,10 @@ typeof navigator === "object" && (function (global, factory) {
     getTitle: function getTitle(videoId) {
       var _this2 = this;
 
+      if (videoId.includes('/shorts/')) {
+        videoId = videoId.replace('/shorts/', '/embed/');
+      }
+
       var url = format(this.config.urls.youtube.api, videoId);
       fetch(url).then(function (data) {
         if (is$1.object(data)) {
@@ -6055,6 +6067,9 @@ typeof navigator === "object" && (function (global, factory) {
         source = player.media.getAttribute(this.config.attributes.embed.id);
       } // Replace the <iframe> with a <div> due to YouTube API issues
 
+      if (source?.includes?.('/shorts/')) {
+        source = source.replace('/shorts/', '/embed/');
+      }
 
       var videoId = parseId$1(source);
       var id = generateId(player.provider); // Get poster, if already set

--- a/js/vendor/plyr.js
+++ b/js/vendor/plyr.js
@@ -1452,7 +1452,8 @@ typeof navigator === "object" && (function (global, factory) {
     airplay: 'AirPlay',
     html5: 'HTML5',
     vimeo: 'Vimeo',
-    youtube: 'YouTube'
+    youtube: 'YouTube',
+    ipfs: 'IPFS',
   };
   var i18n = {
     get: function get() {
@@ -3771,6 +3772,9 @@ typeof navigator === "object" && (function (global, factory) {
         api: 'https://noembed.com/embed?url=https://www.youtube.com/watch?v={0}' // 'https://www.googleapis.com/youtube/v3/videos?id={0}&key={1}&fields=items(snippet(title),fileDetails)&part=snippet',
 
       },
+      ipfs: {
+        source: 'https://ipfs.io/ipfs/{0}'
+      },
       googleIMA: {
         sdk: 'https://imasdk.googleapis.com/js/sdkloader/ima3.js'
       }
@@ -3965,7 +3969,8 @@ typeof navigator === "object" && (function (global, factory) {
   var providers = {
     html5: 'html5',
     youtube: 'youtube',
-    vimeo: 'vimeo'
+    vimeo: 'vimeo',
+    ipfs: 'ipfs',
   };
   var types = {
     audio: 'audio',
@@ -5958,6 +5963,33 @@ typeof navigator === "object" && (function (global, factory) {
     }
   };
 
+  var ipfs = {
+    setup: function setup() {
+      ipfs.ready.call(this);
+    },
+    ready: function ready() {
+      const config = this.config;
+
+      const clearIpfsId = this.media.getAttribute('data-plyr-video-id');
+      var src = format(this.config.urls.ipfs.source, clearIpfsId);
+
+      console.log('SH011', src);
+
+      const embedVideo = createElement('video');
+      embedVideo.setAttribute('src', src);
+      embedVideo.setAttribute('controls', '');
+      embedVideo.setAttribute('autoplay', '');
+
+      embedVideo.controls = true;
+
+      const player = this;
+
+      player.media = replaceElement(embedVideo, player.media);
+
+      ui.build.call(player);
+    }
+  };
+
   // ==========================================================================
 
   function parseId$1(url) {
@@ -6408,6 +6440,8 @@ typeof navigator === "object" && (function (global, factory) {
         youtube.setup.call(this);
       } else if (this.isVimeo) {
         vimeo.setup.call(this);
+      } else if (this.isIpfs) {
+        ipfs.setup.call(this);
       }
     }
   };
@@ -8506,7 +8540,7 @@ typeof navigator === "object" && (function (global, factory) {
     }, {
       key: "isEmbed",
       get: function get() {
-        return Boolean(this.isYouTube || this.isVimeo);
+        return Boolean(this.isYouTube || this.isVimeo || this.isIpfs);
       }
     }, {
       key: "isYouTube",
@@ -8517,6 +8551,11 @@ typeof navigator === "object" && (function (global, factory) {
       key: "isVimeo",
       get: function get() {
         return Boolean(this.provider === providers.vimeo);
+      }
+    }, {
+      key: "isIpfs",
+      get: function get() {
+        return Boolean(this.provider === providers.ipfs);
       }
     }, {
       key: "isVideo",

--- a/js/vendor/plyr.js
+++ b/js/vendor/plyr.js
@@ -5973,8 +5973,6 @@ typeof navigator === "object" && (function (global, factory) {
       const clearIpfsId = this.media.getAttribute('data-plyr-video-id');
       var src = format(this.config.urls.ipfs.source, clearIpfsId);
 
-      console.log('SH011', src);
-
       const embedVideo = createElement('video');
       embedVideo.setAttribute('src', src);
       embedVideo.setAttribute('controls', '');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pocketnet",
-    "version": "0.8.43",
+    "version": "0.8.44",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pocketnet",
-            "version": "0.8.43",
+            "version": "0.8.44",
             "license": "Apache-2.0",
             "dependencies": {
                 "aes-js": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "pocketnet",
-    "version": "0.8.43",
-    "versionsuffix": "4",
-    "cordovaversion": "1.8.43",
-    "cordovaversioncode": "180430",
+    "version": "0.8.44",
+    "versionsuffix": "0",
+    "cordovaversion": "1.8.44",
+    "cordovaversioncode": "180440",
     "description": "Bastyon desktop application",
     "author": "Pocketnet Community <support@pocketnet.app>",
     "company": "Pocketnet Community",


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Fix player not working with "short" type videos from YouTube
- Fix Brighteon player image preview
- Fix Vimeo player image preview
- Refactor `parseVideo()` function. Now it's better in the sense of readability and is more flexible