### PR TITLE
hotfix: proxy16 request

### DIFF
--- a/proxy16/peertube/instance.js
+++ b/proxy16/peertube/instance.js
@@ -151,32 +151,32 @@ var instance = function (host, ip, Roy) {
 
 
 		try {
-		return Roy.parent.transports.fetch(`http://${host}${url}`, {
-			method: p.type || 'get',
-			timeout,
-		}).then(async (result) => {
+			return Roy.parent.transports.fetch(`http://${host}${url}`, {
+				method: p.type || 'get',
+				timeout,
+			}).then(async (result) => {
 
-			const meta = {
-				code: 200,
-				difference: performance.now() - responseTime,
-				method: method,
-			};
+				const meta = {
+					code: 200,
+					difference: performance.now() - responseTime,
+					method: method,
+				};
 
-			statistic.add(meta);
+				statistic.add(meta);
 
-			let resultStr;
+				let resultStr;
 
-			try {
-				resultStr = JSON.parse(await result.text());
-			} catch (err) {
-				resultStr = {};
-			}
+				try {
+					resultStr = JSON.parse(await result.text());
+				} catch (err) {
+					resultStr = {};
+				}
 
-			return Promise.resolve({
-				data: resultStr,
-				meta,
-				host,
-			});
+				return Promise.resolve({
+					data: resultStr,
+					meta,
+					host,
+				});
 			});
 		} catch(error) {
 			const meta = {

--- a/proxy16/peertube/instance.js
+++ b/proxy16/peertube/instance.js
@@ -150,6 +150,7 @@ var instance = function (host, ip, Roy) {
 		}
 
 
+		try {
 		return Roy.parent.transports.fetch(`http://${host}${url}`, {
 			method: p.type || 'get',
 			timeout,
@@ -176,9 +177,8 @@ var instance = function (host, ip, Roy) {
 				meta,
 				host,
 			});
-		})
-		.catch((error) => {
-
+			});
+		} catch(error) {
 			const meta = {
 				code: ((error || {}).response || {}).status || 500,
 				difference: performance.now() - responseTime,
@@ -194,7 +194,7 @@ var instance = function (host, ip, Roy) {
 			statistic.add(meta);
 
 			return Promise.reject(error || {}).response || {};
-		});
+		}
 	};
 
 	self.availability = function(){


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- 0abb997 - Replace **`Promise.catch`** to **`try..catch`**
- f023bda - Just style corrections. Made separately to divide changes

## Other comments:
Proxy16 Peertube instance **`request(method, data, p)`** function located at **`peertube/instance.js:136-198`** is crashing proxy server. Must be tested and accepted in priority.

Seems like **`Promise.catch(...)`** is not able to catch some errors what produce uncaught errors in global scope. Replacing with **`try..catch`** must resolve the issue.