### PR TITLE
fix: image upload show conditions

### DIFF
--- a/components/share/templates/postline.html
+++ b/components/share/templates/postline.html
@@ -6,7 +6,16 @@
 
             <% if(!external) {%>
             
-                <% if(!share.itisvideo() && !share.itisaudio()) {%>
+                <%
+                const isIpfs = share.itisipfs()
+                const isEmbed = share.itisembed()
+                const isPlayer = share.itisvideo() || share.itisaudio()
+
+                const condition1 = (isIpfs && !isPlayer)
+                const condition2 = (!isPlayer && !isIpfs && !isEmbed)
+                %>
+
+                <% if(condition1 || condition2) {%>
 
                     <div elementsid="saddimages" class="item images tooltip" title="<%=e('saddimages')%>">
                         <i class="fas fa-camera"></i> <span class="mobiledevice"><%=e('saddimages')%></span>

--- a/js/kit.js
+++ b/js/kit.js
@@ -1492,6 +1492,32 @@ Share = function(lang){
 		if(meta.type == 'peertube' && ch && ch.length > 0 && ch[ch.length - 1] == 'audio') return true
 	}
 
+	self.itisembed = function(){
+		if (self.settings.v === 'a' || !self.url?.v) {
+			return;
+		}
+
+		const meta = parseVideo(self.url.v);
+
+		const isYoutube = (meta.type === 'youtube');
+		const isVimeo = (meta.type === 'vimeo');
+		const isBitchute = (meta.type === 'bitchute');
+		const isBrighteon = (meta.type === 'brighteon' || meta.type === 'stream.brighteon');
+		const isIpfs = (meta.type === 'ipfs');
+
+		return (isYoutube || isVimeo || isBitchute || isBrighteon || isIpfs);
+	}
+
+	self.itisipfs = function(){
+		if (self.settings.v === 'a' || !self.url?.v) {
+			return;
+		}
+
+		const meta = parseVideo(self.url.v);
+
+		return (meta.type === 'ipfs');
+	}
+
 	self.itisstream = function(){
 
 		if(self.settings.v == 'a') return
@@ -2307,6 +2333,32 @@ pShare = function(){
 		var ch = self.url.replace('peertube://', '').split('/')
 
 		if(meta.type == 'peertube' && ch && ch.length > 0 && ch[ch.length - 1] == 'audio') return true
+	}
+
+	self.itisembed = function(){
+		if (self.settings.v === 'a' || !self.url?.v) {
+			return;
+		}
+
+		const meta = parseVideo(self.url.v);
+
+		const isYoutube = (meta.type === 'youtube');
+		const isVimeo = (meta.type === 'vimeo');
+		const isBitchute = (meta.type === 'bitchute');
+		const isBrighteon = (meta.type === 'brighteon' || meta.type === 'stream.brighteon');
+		const isIpfs = (meta.type === 'ipfs');
+
+		return (isYoutube || isVimeo || isBitchute || isBrighteon || isIpfs);
+	}
+
+	self.itisipfs = function(){
+		if (self.settings.v === 'a' || !self.url?.v) {
+			return;
+		}
+
+		const meta = parseVideo(self.url.v);
+
+		return (meta.type === 'ipfs');
 	}
 
 	self.itisstream = function(){


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Add `itisembed()` to check if post has embedded player
- Add `itisipfs()` to check if post has embedded player with IPFS video
- Rewrite conditions for image upload UI

## Other comments:
New conditions are allowing image upload UI for next cases...
- If post contains IPFS video. Then the uploaded image would be used for player thumbnail upload as was introduced in #1040
- If post doesn't contain video player, excluding IPFS player

Functions are documented in this PR [here](https://github.com/pocketnetteam/pocketnet.gui/pull/1043#issuecomment-1554254032).

Code is not efficient due to functions duplications.