### PR TITLE
hotfix: update ui called on latest producing error

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1263,6 +1263,10 @@ Application = function(p)
             setTimeout(() => {
               self.mobile.update.hasupdatecheck()
                   .then((updateInfo) => {
+                    if (!updateInfo) {
+                      return;
+                    }
+
                     const skippedUpdate = JSON.parse(localStorage.updateNotifier || '{}');
 
                     if ('version' in skippedUpdate) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pocketnet",
-    "version": "0.8.49",
+    "version": "0.8.51",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pocketnet",
-            "version": "0.8.49",
+            "version": "0.8.51",
             "license": "Apache-2.0",
             "dependencies": {
                 "aes-js": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "pocketnet",
-    "version": "0.8.50",
+    "version": "0.8.51",
     "versionsuffix": "1",
-    "cordovaversion": "1.8.50",
-    "cordovaversioncode": "180500",
+    "cordovaversion": "1.8.51",
+    "cordovaversioncode": "180510",
     "description": "Bastyon desktop application",
     "author": "Pocketnet Community <support@pocketnet.app>",
     "company": "Pocketnet Community",


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Forgotten condition was producing ghost update UI calls.

## Other comments:
Done in context of #1030