### PR TITLE
fix: all tor events being dismounted and likes functionality

### DIFF
--- a/components/post/index.js
+++ b/components/post/index.js
@@ -1544,8 +1544,6 @@ var post = (function () {
 			},
 			stars: function (clbk) {
 
-				console.log('share', share)
-
 				self.shell(
 					{
 						turi: 'lenta',
@@ -1859,12 +1857,10 @@ var post = (function () {
 
 				if(type == 'upvoteShare'){
 
-					console.log('share.txid == alias.share.v', share.txid, alias.share.v)
-
 					if (share.txid == alias.share.v){
 
 						share = self.psdk.share.get(share.txid) 
-						
+
 						renders.stars()
 					}
 				}

--- a/components/post/index.js
+++ b/components/post/index.js
@@ -1543,6 +1543,9 @@ var post = (function () {
 				}
 			},
 			stars: function (clbk) {
+
+				console.log('share', share)
+
 				self.shell(
 					{
 						turi: 'lenta',
@@ -1856,7 +1859,12 @@ var post = (function () {
 
 				if(type == 'upvoteShare'){
 
+					console.log('share.txid == alias.share.v', share.txid, alias.share.v)
+
 					if (share.txid == alias.share.v){
+
+						share = self.psdk.share.get(share.txid) 
+						
 						renders.stars()
 					}
 				}

--- a/js/broadcaster.js
+++ b/js/broadcaster.js
@@ -85,6 +85,10 @@ class Broadcaster {
         });
     }
 
+    removeAllNamed(name) {
+        delete this.listeners[name];
+    }
+
     removeAllListeners() {
         this.listeners = {};
     }

--- a/js/satolist.js
+++ b/js/satolist.js
@@ -5820,12 +5820,12 @@ Platform = function (app, listofnodes) {
             clbks : {},
             history : [],
             init : function(clbk){
-                if(typeof swBroadcaster != 'undefined')
-                    swBroadcaster.removeAllListeners();
+                if(typeof swBroadcaster != 'undefined') {
+                    swBroadcaster.removeAllNamed('network-stats');
 
                     swBroadcaster.on('network-stats', (data) => {
 
-                        if (self.sdk.broadcaster.history.length > 600){
+                        if (self.sdk.broadcaster.history.length > 600) {
                             self.sdk.broadcaster.history.splice(0, 100)
                         }
 


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- New method for Broadcaster to clear specific named events group
- Clear only network-stats event

## Other comments:
Related to #1083