### PR TITLE
fix: show version on mobile when update available

### DIFF
--- a/components/userpage/index.css
+++ b/components/userpage/index.css
@@ -211,6 +211,11 @@
   opacity: 0.5;
   font-weight: 500;
 }
+#userpage .maketsWrapper .contents .reportCaption .hasupdate {
+  display: block;
+  margin: 0 auto;
+  margin-bottom: 20px;
+}
 #userpage .maketsWrapper .contents .addmenu .reportCaption {
   font-weight: 400;
 }

--- a/components/userpage/index.less
+++ b/components/userpage/index.less
@@ -280,6 +280,12 @@
 					opacity: 0.5;
 					font-weight: 500;
 				}
+
+				.hasupdate {
+					display: block;
+					margin: 0 auto;
+					margin-bottom: 20px;
+				}
 			}
 
 			.addmenu{

--- a/components/userpage/templates/contents.html
+++ b/components/userpage/templates/contents.html
@@ -178,17 +178,15 @@
                         </button>
 
                         
-                    <% } else { %> 
+                    <% } %>
 
-                        <span class="applicaitonversion">
-                            <%=e('applicationversion')%> &middot; <%- window.packageversion %>
-                        </span>
-                        
-                        <% if (window.builtfromsha) { %>
-                            &nbsp;&middot;&nbsp;
-                            <span class="app-builtfrom"><%- window.builtfromsha %></span>
-                        <% } %>
+                    <span class="applicaitonversion">
+                        <%=e('applicationversion')%> &middot; <%- window.packageversion %>
+                    </span>
 
+                    <% if (window.builtfromsha) { %>
+                        &nbsp;&middot;&nbsp;
+                        <span class="app-builtfrom"><%- window.builtfromsha %></span>
                     <% } %>
                     
                 </div>


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Show version on mobile anyway

## Other comments:
When update is available, current mobile application version is not showing up. For debug reasons must be showed too

#### Image of UI after changes
![After changes](https://github.com/pocketnetteam/pocketnet.gui/assets/22795961/d92f6740-54de-4fb0-af49-4015537586b6)