### PR TITLE
Add viewers of stream and show comments after video ends

### DIFF
--- a/components/lenta/templates/stars.html
+++ b/components/lenta/templates/stars.html
@@ -99,6 +99,12 @@
 			<% if(Number(share.scnt)) {%> <div class="countusers"><i class="far fa-user"></i><span class="c"><%-Number(share.scnt)%></span></div> <% } %>
 			<% } %>
 		</div>
+
+		<% if(videoMeta?.viewers) {%>
+		<div elementsid="viewdetails" class="count">
+			<div class="countusers"><i class="far fa-eye"></i><span class="c"><%-Number(videoMeta.viewers)%></span></div>
+		</div>
+		<% } %>
 		
 	<% } %>
 

--- a/components/post/index.js
+++ b/components/post/index.js
@@ -1145,11 +1145,15 @@ var post = (function () {
 		var renders = {
 			comments: function (clbk) {
 				if ((!ed.repost || ed.fromempty) && ed.comments != 'no') {
-					if (!share.settings.c) {
+					const
+						meta = window.parseVideo(share.url),
+						state = _.clone(window.peertubeglobalcache[meta?.id]);
+
+					if (!state?.isLive || !share.settings.c) {
 						self.fastTemplate(
 							'commentspreview',
 							function (rendered) {
-								var _el = el.c.find('.commentsWrapper');
+								var _el = el.c.find('.commentsWrapper').addClass('commentsVisible');
 	
 								var rf = '';
 	
@@ -1616,6 +1620,9 @@ var post = (function () {
 				}
 			},
 			stars: function (clbk) {
+				const
+					meta = window.parseVideo(share.url),
+					state = _.clone(window.peertubeglobalcache[meta?.id]);
 
 				self.shell(
 					{
@@ -1624,6 +1631,7 @@ var post = (function () {
 						el: el.stars,
 						data: {
 							share: share,
+							videoMeta: state
 						},
 						ignorelinksandimages : true,
 						animation : false,	


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
<!--
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
-->
- [x] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- Fix add count of viewers in stream and show comments block after stream ends