### PR TITLE
fix: comment overflowed by ui icons

### DIFF
--- a/components/comments/index.css
+++ b/components/comments/index.css
@@ -992,7 +992,7 @@
   border-radius: 3px;
   padding: 8px;
   padding-left: 1em;
-  padding-right: 64px;
+  padding-right: 110px;
   outline: none;
   border: 0;
   min-height: 36px;

--- a/components/comments/index.less
+++ b/components/comments/index.less
@@ -1180,7 +1180,7 @@
 			border-radius: 3px;
 			padding : 8px;
 			padding-left : 2 * @rhythm;
-			padding-right : 64px;
+			padding-right : 110px;
 			outline: none;
 			border : 0;
 			min-height: 36px;


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable, and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Set 110px instead of 64px

## Other comments:

#### BEFORE
![Before](https://github.com/pocketnetteam/pocketnet.gui/assets/22795961/ea3fa173-7e91-4a6f-9fb8-0729c3c50d8e)

#### AFTER
![After](https://github.com/pocketnetteam/pocketnet.gui/assets/22795961/75ccff64-2d8a-48cd-881d-c476504df93a)
