### PR TITLE
feat: transcoding update ffmpeg to 6.1

### DIFF
--- a/js/electron/transcoding2.js
+++ b/js/electron/transcoding2.js
@@ -192,6 +192,7 @@ class BinariesDownloader {
 
       const options = {
         destination: this.path,
+        version: '6.1',
         tickerFn: ({progress}) => {
           if (progress < lastProgress) {
             return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pocketnet",
-    "version": "0.8.75",
+    "version": "0.8.76",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pocketnet",
-            "version": "0.8.75",
+            "version": "0.8.76",
             "license": "Apache-2.0",
             "dependencies": {
                 "aes-js": "^3.1.2",


### PR DESCRIPTION
The latest version of FFMPEG and FFBinaries is 6.1, but 4.4.1 is used by default

## Standards checklist:
- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] The PR has self-explained commits history.
- [ ] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable, and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Use FFMPEG and FFBINARIES of version 6.1

## Other comments:
Currently, FFBinaries uses default 4.4.1. Setting it to use latest one.