### PR TITLE
repo: allow failed jobs on release

### DIFF
--- a/.github/workflows/build.release.yml
+++ b/.github/workflows/build.release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
 


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable, and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Allow to proceed release jobs if any of them failed to end

## Other comments:
For some reason, our workflow has issues with macOS builds last weeks. This would allow us to build all but macOS at least and made the macOS build manually.
