### PR TITLE
feat: support IPFS images for user logo and additional field in edit profile

### DIFF
--- a/components/test/index.js
+++ b/components/test/index.js
@@ -672,6 +672,15 @@ var test = (function(){
 					name : self.app.localization.e('uwebsite')
 				}),
 
+				imageUrl : new Parameter({
+					name : self.app.localization.e('uimageUrl'),
+					placeholder : self.app.localization.e('uimageUrlPlaceholder'),
+					id : 'image',
+					type : "IMAGEURL",
+					onType : true,
+					require : false
+				}),
+
 				addresses : new function(){
 
 					var _self = this;

--- a/js/functions.js
+++ b/js/functions.js
@@ -10607,6 +10607,15 @@ var connectionSpeed = function()
     return defaultSpeed;
 };
 
+replaceIpfsCID = function(src) {
+	if (src.startsWith('/ipfs/')) {
+		// TODO (aok) - replace with ipfs gateways array
+		return src.replace('/ipfs/', 'https://ipfs.1.pocketnet.app/ipfs/');
+	}
+
+	return src;
+};
+
 replaceArchiveInImage = function(src) {
 	var srcNew = src;
 
@@ -10614,8 +10623,9 @@ replaceArchiveInImage = function(src) {
 		if (srcNew.includes(server)) srcNew = srcNew.replace(server, 'peertube.archive.pocketnet.app');
 	});
 
+	srcNew = srcNew.replace('bastyon.com:8092', 'pocketnet.app:8092').replace('test.pocketnet', 'pocketnet').replace('https://http://', 'http://');
 
-	return srcNew.replace('bastyon.com:8092', 'pocketnet.app:8092').replace('test.pocketnet', 'pocketnet').replace('https://http://', 'http://');
+	return replaceIpfsCID(srcNew);
 };
 
 function Circles(params) {

--- a/localization/en.js
+++ b/localization/en.js
@@ -228,6 +228,8 @@ _l.uabout = "About myself";
 _l.uwebsite = "Web Site";
 _l.uaddresesd = "Addresses for Donations";
 _l.usavechanges = "Do you want to save your changes?";
+_l.uimageUrl = "Profile image url";
+_l.uimageUrlPlaceholder = "Enter your image or ipfs link";
 
 _l.settings_save = "Save changes";
 _l.settings_discard = "Discard changes";

--- a/localization/ru.js
+++ b/localization/ru.js
@@ -224,6 +224,8 @@ _l.uabout = "О себе";
 _l.uwebsite = "Веб сайт";
 _l.uaddresesd = "Адреса для пожертвований";
 _l.usavechanges = "Вы хотите сохранить изменения?";
+_l.uimageUrl = "Url иконки пользователя";
+_l.uimageUrlPlaceholder = "Url иконки или ipfs хеш";
 
 _l.settings_save = "Сохранить изменения";
 _l.settings_discard = "Сбросить изменения";


### PR DESCRIPTION
## Standards checklist:

<!---

Pull request must have next naming format:
  - For fixes use "fix:" prefix, e.g. "fix: video transcoding"
  - For patches use "patch:" prefix, e.g. "patch: docker image change"
  - For features use "feat:" prefix, e.g. "feat: voice messages"
  - For refactoring use "refactor:" prefix, e.g. "refactor: workflow actions"
  - For documentation use "docs:" prefix, e.g. "docs: readme.md header logo"

// TODO: Airbnb code style guide

-->

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] The PR has self-explained commits history.
<!--
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
-->
- [X] The code is mine or it's from somewhere with an Apache-2.0 compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:

- Added IPFS support for the user's icon
- Added an additional field for the `image` field in the `userProfile`

## Other comments:

I suggest starting IPFS integration to be able to upload content to the IPFS network. This PR offers a starting point for the implementation of full-fledged support in order to study the load on the IPFS gateway (ipfs.1.pocketnet.app) and search for possible problems and bottlenecks.
