### PR TITLE
patch: update static nodes list

### DIFF
--- a/proxy16/kit.js
+++ b/proxy16/kit.js
@@ -181,7 +181,79 @@ var activenodes = [
 		sws : SecureWsPort,
 		name : '172.83.108.40',
 		stable : true
-	}
+	},
+	{
+		host : '95.31.45.162',
+		port : WebPort,
+		ws : WsPort,
+		sport : SecureWebPort,
+		sws : SecureWsPort,
+		name : '95.31.45.162',
+		stable : true
+	},
+	{
+		host : '79.143.35.233',
+		port : WebPort,
+		ws : WsPort,
+		sport : SecureWebPort,
+		sws : SecureWsPort,
+		name : '79.143.35.233',
+		stable : true
+	},
+	{
+		host : '109.197.196.106',
+		port : WebPort,
+		ws : WsPort,
+		sport : SecureWebPort,
+		sws : SecureWsPort,
+		name : '109.197.196.106',
+		stable : true
+	},
+	{
+		host : '50.65.56.253',
+		port : WebPort,
+		ws : WsPort,
+		sport : SecureWebPort,
+		sws : SecureWsPort,
+		name : '50.65.56.253',
+		stable : true
+	},
+	{
+		host : '65.21.252.135',
+		port : WebPort,
+		ws : WsPort,
+		sport : SecureWebPort,
+		sws : SecureWsPort,
+		name : '65.21.252.135',
+		stable : true
+	},
+	{
+		host : '178.217.159.221',
+		port : WebPort,
+		ws : WsPort,
+		sport : SecureWebPort,
+		sws : SecureWsPort,
+		name : '178.217.159.221',
+		stable : true
+	},
+	{
+		host : '178.217.159.227',
+		port : WebPort,
+		ws : WsPort,
+		sport : SecureWebPort,
+		sws : SecureWsPort,
+		name : '178.217.159.221',
+		stable : true
+	},
+	{
+		host : '65.21.56.203',
+		port : WebPort,
+		ws : WsPort,
+		sport : SecureWebPort,
+		sws : SecureWsPort,
+		name : '65.21.56.203',
+		stable : true
+	},
 ]
 
 var nodes = activenodes

--- a/proxy16/kit.js
+++ b/proxy16/kit.js
@@ -124,27 +124,6 @@ var activenodes = [
 		name : '202.61.253.55',
 		stable : true
 	},
-
-	{
-		host : '140.99.153.138',
-		port : WebPort,
-		ws : WsPort,
-		sport : SecureWebPort,
-		sws : SecureWsPort,
-		name : '140.99.153.138',
-		stable : true
-	},
-
-	{
-		host : '172.83.108.41',
-		port : WebPort,
-		ws : WsPort,
-		sport : SecureWebPort,
-		sws : SecureWsPort,
-		name : '172.83.108.41',
-		stable : true
-	},
-
 	{
 		host : '207.180.201.246', ///
 		port : WebPort,
@@ -171,15 +150,6 @@ var activenodes = [
 		sport : SecureWebPort,
 		sws : SecureWsPort,
 		name : '162.246.52.155',
-		stable : true
-	},
-	{
-		host : '172.83.108.40',
-		port : WebPort,
-		ws : WsPort,
-		sport : SecureWebPort,
-		sws : SecureWsPort,
-		name : '172.83.108.40',
 		stable : true
 	},
 	{
@@ -210,15 +180,6 @@ var activenodes = [
 		stable : true
 	},
 	{
-		host : '50.65.56.253',
-		port : WebPort,
-		ws : WsPort,
-		sport : SecureWebPort,
-		sws : SecureWsPort,
-		name : '50.65.56.253',
-		stable : true
-	},
-	{
 		host : '65.21.252.135',
 		port : WebPort,
 		ws : WsPort,
@@ -229,15 +190,6 @@ var activenodes = [
 	},
 	{
 		host : '178.217.159.221',
-		port : WebPort,
-		ws : WsPort,
-		sport : SecureWebPort,
-		sws : SecureWsPort,
-		name : '178.217.159.221',
-		stable : true
-	},
-	{
-		host : '178.217.159.227',
 		port : WebPort,
 		ws : WsPort,
 		sport : SecureWebPort,


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [ ] ~The code is mine, or it's from somewhere with an Apache-2.0 compatible license.~
- [ ] ~The code is efficient, to the best of my ability, and does not waste computer resources.~
- [ ] ~The code is stable, and I have tested it myself, to the best of my abilities.~
- [ ] ~If the code introduces new classes, methods, I provide a valid use case for all of them.~

## Changes:
- Remove 3 offline static nodes
  - 140.99.153.138
  - 172.83.108.41
  - 172.83.108.40
- Add 6 online static nodes
  - 95.31.45.162
  - 79.143.35.233
  - 109.197.196.106
  - 65.21.252.135
  - 178.217.159.221
  - 65.21.56.203

## Other comments:
This patch is based on network checks and Pocketnet.core official list.

https://github.com/pocketnetteam/pocketnet.core/blob/83418e8cc40cc672aaf9221ee4fa8b7856273f79/contrib/seeds/nodes_main.txt