### PR TITLE
patch: set version to 0.8.85

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pocketnet",
-    "version": "0.8.82",
+    "version": "0.8.85",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pocketnet",
-            "version": "0.8.82",
+            "version": "0.8.85",
             "license": "Apache-2.0",
             "dependencies": {
                 "@seald-io/nedb": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
     "name": "pocketnet",
     "project": "Bastyon",
 
-    "version": "0.8.84",
-    "versionsuffix": "1",
-    "cordovaversion": "1.8.84",
-    "cordovaversioncode": "180841",
+    "version": "0.8.85",
+    "versionsuffix": "0",
+    "cordovaversion": "1.8.85",
+    "cordovaversioncode": "180850",
 
     "description": "Bastyon desktop application",
     "author": "Pocketnet Community <support@pocketnet.app>",


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The PR has self-explained commits history.
- [x] The code is mine, or it's from somewhere with an Apache-2.0 compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new classes, methods, I provide a valid use case for all of them.

## Changes:
- Set version to 0.8.85

## Other comments:
Some users who updated to the faulty release 0.8.84 on April 8, 2024, are experiencing difficulties updating to the corrected version released on April 9, 2024, bearing the same version number. To address this issue, we are releasing version 0.8.85 as a resolution.

Related to PR's #1223 and #1175