### PR TITLE
fix: navigation for socialshare dialog

### DIFF
--- a/js/satolist.js
+++ b/js/satolist.js
@@ -4065,7 +4065,7 @@ Platform = function (app, listofnodes) {
             app.nav.api.load({
                 open : true,
                 href : 'socialshare2',
-                history : true,
+                history : false,
                 inWnd : true,
 
                 essenseData : {


### PR DESCRIPTION
<!--
📣 READ CAREFULLY BEFORE CREATING THIS PR 📣
1️⃣ This PR template is exclusively for FIX
2️⃣ The PR title must start from "fix:"
3️⃣ The PR title must be written in lowercase
4️⃣ The topic must be provided with requested below information
-->

## Standards checklist:
- [ ] The PR title is descriptive
- [ ] There is no PR that addresses this issue
- [ ] The PR has self-explained commits history
- [ ] The code is mine or has Apache-2.0 compatible license
- [ ] The code is efficient enough, it respects user resources
- [ ] The code is stable and tested
- [ ] There is new functionality, information is provided below

## Changes:
...

## Other comments:
After closing the socialshare dialog form, two identical entries are added to the browser history stack. Because of this, you have to press the back button 3 times to return to the previous page. This behavior is incorrect. The simple solution is to show the form without adding to the history stack.
