### PR TITLE
fix: hide miniappscnt when applicationfx is active

### DIFF
--- a/components/application/index.js
+++ b/components/application/index.js
@@ -360,7 +360,7 @@ var application = (function(){
             .join("; ");
         };
 
-				p.el.find('#miniappscnt').hide();
+				self.app.el.miniapps.hide();
 
         const iframeAllowAttr = buildIframeAllowAttr(grantedPermissions || []);
 
@@ -602,7 +602,7 @@ var application = (function(){
 
 				self.app.apps.off('permissions:changed', events.permissionsChanged)
 				
-				$('#miniappscnt').show();
+				self.app.el.miniapps.show();
 
 				self.app.apps.off('installed', events.installed)
 				self.app.apps.off('removed', events.removed)

--- a/components/application/index.js
+++ b/components/application/index.js
@@ -360,6 +360,8 @@ var application = (function(){
             .join("; ");
         };
 
+				p.el.find('#miniappscnt').hide();
+
         const iframeAllowAttr = buildIframeAllowAttr(grantedPermissions || []);
 
 				
@@ -599,12 +601,13 @@ var application = (function(){
 				self.app.apps.off('changestate', events.changestate)
 
 				self.app.apps.off('permissions:changed', events.permissionsChanged)
+				
+				$('#miniappscnt').show();
 
 				self.app.apps.off('installed', events.installed)
 				self.app.apps.off('removed', events.removed)
 
-				delete self.app.platform.matrixchat.clbks.ALL_NOTIFICATIONS_COUNT.application
-
+					delete self.app.platform.matrixchat.clbks.ALL_NOTIFICATIONS_COUNT.application
 			},
 			
 			init : function(p){


### PR DESCRIPTION
<!--
📣 READ CAREFULLY BEFORE CREATING THIS PR 📣
1️⃣ This PR template is exclusively for FIX
2️⃣ The PR title must start from "fix:"
3️⃣ The PR title must be written in lowercase
4️⃣ The topic must be provided with requested below information
-->

## Standards checklist:
- [x] The PR title is descriptive
- [x] There is no PR that addresses this issue
- [x] The PR has self-explained commits history
- [x] The code is mine or has Apache-2.0 compatible license
- [x] The code is efficient enough, it respects user resources
- [x] The code is stable and tested
- [x] There is new functionality, information is provided below

## Changes:
...

## Other comments:
...
