### PR TITLE
fix: avoid unnecessary servers ping

### DIFF
--- a/proxy16/transports.js
+++ b/proxy16/transports.js
@@ -70,17 +70,19 @@ class WrappedAxios {
 
         const preparedArgs = WrappedAxios.prepareArguments(...args);
 
-        const hasDirectAccess = await this.transports.hasDirectAccess(preparedArgs.url);
+        const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
         const isDirectAccessRestricted = (torCtrl.settings.enabled2 === 'always');
-        const useDirectAccess = (hasDirectAccess && !isDirectAccessRestricted);
-
+        let useDirectAccess = false;
+        if (!isTorEnabledInSettings) {
+            useDirectAccess = true;
+        } else if (!isDirectAccessRestricted) {
+            useDirectAccess = await this.transports.hasDirectAccess(preparedArgs.url);
+        }
         let isTorReady = this.transports.isTorReady();
 
         if (isDirectAccessRestricted) {
             isTorReady = await this.transports.waitTorReady();
         }
-
-        const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
         const useTor = (!useDirectAccess && isTorReady && isTorEnabledInSettings);
 
         if (useTor) {
@@ -112,20 +114,21 @@ class WrappedAxios {
                     return Promise.reject(error)
                 }
 
-            
-                var hasDirectAccess = await this.transports.hasDirectAccess(preparedArgs.url);
-                var isDirectAccessRestricted = (torCtrl.settings.enabled2 === 'always');
-                var useDirectAccess = (hasDirectAccess && !isDirectAccessRestricted);
+                const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
+                const isDirectAccessRestricted = (torCtrl.settings.enabled2 === 'always');
+                let useDirectAccess = false;
+                if (!isTorEnabledInSettings) {
+                    useDirectAccess = true;
+                } else if (!isDirectAccessRestricted) {
+                    useDirectAccess = await this.transports.hasDirectAccess(preparedArgs.url);
+                }
                 let isTorReady = this.transports.isTorReady();
 
                 if (isDirectAccessRestricted) {
                     isTorReady = await this.transports.waitTorReady();
                 }
 
-                var isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
                 var useTor = (!useDirectAccess && isTorReady && isTorEnabledInSettings);
-
-
                 if (useTor) {
                     const isTorAutoEnabled = (torCtrl.settings.enabled2 === 'auto');
 
@@ -191,19 +194,21 @@ class WrappedFetch {
 
         const preparedArgs = {...options};
 
-        const hasDirectAccess = await this.transports.hasDirectAccess(url);
+        const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
         const isDirectAccessRestricted = (torCtrl.settings.enabled2 === 'always');
-        const useDirectAccess = (hasDirectAccess && !isDirectAccessRestricted);
-
+        let useDirectAccess = false;
+        if (!isTorEnabledInSettings) {
+            useDirectAccess = true;
+        } else if (!isDirectAccessRestricted) {
+            useDirectAccess = await this.transports.hasDirectAccess(url);
+        }
         let isTorReady = this.transports.isTorReady();
 
         if (isDirectAccessRestricted) {
             isTorReady = await this.transports.waitTorReady();
         }
 
-        const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
         const useTor = (!useDirectAccess && isTorReady && isTorEnabledInSettings);
-
         if (useTor) {
             const isTorAutoEnabled = (torCtrl.settings.enabled2 === 'auto');
 
@@ -236,19 +241,21 @@ class WrappedFetch {
                     return Promise.reject(error)
                 }
 
-                const hasDirectAccess = await this.transports.hasDirectAccess(url);
+                const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
                 const isDirectAccessRestricted = (torCtrl.settings.enabled2 === 'always');
-                const useDirectAccess = (hasDirectAccess && !isDirectAccessRestricted);
-
+                let useDirectAccess = false;
+                if (!isTorEnabledInSettings) {
+                    useDirectAccess = true;
+                } else if (!isDirectAccessRestricted) {
+                    useDirectAccess = await this.transports.hasDirectAccess(url);
+                }
                 let isTorReady = this.transports.isTorReady();
 
                 if (isDirectAccessRestricted) {
                     isTorReady = await this.transports.waitTorReady();
                 }
 
-                const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
                 const useTor = (!useDirectAccess && isTorReady && isTorEnabledInSettings);
-
                 if (useTor) {
                     const isTorAutoEnabled = (torCtrl.settings.enabled2 === 'auto');
 
@@ -317,19 +324,21 @@ class WrappedRequest {
 
         const preparedArgs = {...options};
 
-        const hasDirectAccess = await this.transports.hasDirectAccess(preparedArgs.url);
+        const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
         const isDirectAccessRestricted = (torCtrl.settings.enabled2 === 'always');
-        const useDirectAccess = (hasDirectAccess && !isDirectAccessRestricted);
-
+        let useDirectAccess = false;
+        if (!isTorEnabledInSettings) {
+            useDirectAccess = true;
+        } else if (!isDirectAccessRestricted) {
+            useDirectAccess = await this.transports.hasDirectAccess(preparedArgs.url);
+        }
         let isTorReady = this.transports.isTorReady();
 
         if (isDirectAccessRestricted) {
             isTorReady = await this.transports.waitTorReady();
         }
 
-        const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
         const useTor = (!useDirectAccess && isTorReady && isTorEnabledInSettings);
-
         if (useTor) {
             const isTorAutoEnabled = (torCtrl.settings.enabled2 === 'auto');
 
@@ -355,19 +364,21 @@ class WrappedRequest {
                     callback?.(preparedResult.error, response, body);
                 }
 
-                const hasDirectAccess = await this.transports.hasDirectAccess(url);
+                const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
                 const isDirectAccessRestricted = (torCtrl.settings.enabled2 === 'always');
-                const useDirectAccess = (hasDirectAccess && !isDirectAccessRestricted);
-
+                let useDirectAccess = false;
+                if (!isTorEnabledInSettings) {
+                    useDirectAccess = true;
+                } else if (!isDirectAccessRestricted) {
+                    useDirectAccess = await this.transports.hasDirectAccess(preparedArgs.url);
+                }
                 let isTorReady = this.transports.isTorReady();
 
                 if (isDirectAccessRestricted) {
                     isTorReady = await this.transports.waitTorReady();
                 }
-                
-                const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
-                const useTor = (!useDirectAccess && isTorReady && isTorEnabledInSettings);
 
+                const useTor = (!useDirectAccess && isTorReady && isTorEnabledInSettings);
                 if (useTor) {
                     const isTorAutoEnabled = (torCtrl.settings.enabled2 === 'auto');
 
@@ -614,19 +625,22 @@ class Transports {
     async isTorNeeded(url) {
         const torCtrl = this.torapplications;
 
-        const hasDirectAccess = await this.hasDirectAccess(url);
-        const isDirectRestricted = (torCtrl.settings.enabled2 === 'always');
-        const isTorAutoEnabled = (torCtrl.settings.enabled2 === 'auto');
-        const useDirectAccess = (hasDirectAccess && !isDirectRestricted);
+        const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
+        const isDirectAccessRestricted = (torCtrl.settings.enabled2 === 'always');
+        let useDirectAccess = false;
+        if (!isTorEnabledInSettings) {
+            useDirectAccess = true;
+        } else if (!isDirectAccessRestricted) {
+            useDirectAccess = await this.hasDirectAccess(url);
+        }
 
         let isTorReady = this.isTorReady();
 
-        if (isDirectRestricted || (isTorAutoEnabled && !hasDirectAccess && !isTorReady)) {
+        if (!useDirectAccess && !isTorReady) {
             torCtrl.start();
             isTorReady = await this.waitTorReady();
         }
 
-        const isTorEnabledInSettings = (torCtrl.settings.enabled2 !== 'neveruse');
         const useTor = (!useDirectAccess && isTorReady && isTorEnabledInSettings);
 
         return !!useTor;


### PR DESCRIPTION
<!--
📣 READ CAREFULLY BEFORE CREATING THIS PR 📣
1️⃣ This PR template is exclusively for FIX
2️⃣ The PR title must start from "fix:"
3️⃣ The PR title must be written in lowercase
4️⃣ The topic must be provided with requested below information
-->

## Standards checklist:
- [x] The PR title is descriptive
- [x] There is no PR that addresses this issue
- [x] The PR has self-explained commits history
- [x] The code is mine or has Apache-2.0 compatible license
- [x] The code is efficient enough, it respects user resources
- [x] The code is stable and tested
- [x] There is new functionality, information is provided below

## Changes:
The original implementation pings servers regardless of user settings. The fixed implementation pings servers only when really necessary, when the user has configured to use Tor automatically. This eliminates excessive load on servers when the user has configured to never use Tor, and eliminates data leaks when the user has configured to always use Tor.

## Other comments:
...
