### PR TITLE
fix: change port of tor socks proxy

### DIFF
--- a/proxy16/node/torcontrol.js
+++ b/proxy16/node/torcontrol.js
@@ -223,7 +223,7 @@ class TorControl {
             "# The user is free to edit this config if he know\n" +
             "# how to do that. Read TOR documentation before...\n",
 
-            "SocksPort 0.0.0.0:9151",
+            "SocksPort 0.0.0.0:9051",
             "CookieAuthentication 1",
             "DormantCanceledByStartup 1",
             `DataDirectory ${getSettingsPath("data")}`,

--- a/proxy16/transports.js
+++ b/proxy16/transports.js
@@ -173,7 +173,7 @@ class WrappedAxios {
     }
 
     static handleError(error) {
-        const isConnRefused = error.message.includes('ECONNREFUSED 127.0.0.1:9151');
+        const isConnRefused = error.message.includes('ECONNREFUSED 127.0.0.1:9051');
         const isSocksRejection = error.message.includes('Socks5 proxy rejected connection');
 
         if (isConnRefused || isSocksRejection) {
@@ -310,7 +310,7 @@ class WrappedFetch {
     }
 
     static handleError(error) {
-        const isConnRefused = error.message.includes('ECONNREFUSED 127.0.0.1:9151');
+        const isConnRefused = error.message.includes('ECONNREFUSED 127.0.0.1:9051');
         const isSocksRejection = error.message.includes('Socks5 proxy rejected connection');
 
         if (isConnRefused || isSocksRejection) {
@@ -441,7 +441,7 @@ class WrappedRequest {
     }
 
     static handleError(error) {
-        const isConnRefused = error.message.includes('ECONNREFUSED 127.0.0.1:9151');
+        const isConnRefused = error.message.includes('ECONNREFUSED 127.0.0.1:9051');
         const isSocksRejection = error.message.includes('Socks5 proxy rejected connection');
 
         if (isConnRefused || isSocksRejection) {
@@ -672,7 +672,7 @@ class Transports {
 
     getTorAgent() {
         if (!this.torAgent) {
-            const url = new URL('socks5h://127.0.0.1:9151');
+            const url = new URL('socks5h://127.0.0.1:9051');
             url.tls = { rejectUnauthorized: false };
             this.torAgent = new SocksProxyAgent(url, {
                 keepAlive: true,
@@ -718,7 +718,7 @@ class Transports {
     }
 
     isTorRefuseConnections(error) {
-        return error.message.includes('ECONNREFUSED 127.0.0.1:9151');
+        return error.message.includes('ECONNREFUSED 127.0.0.1:9051');
     }
 }
 


### PR DESCRIPTION
<!--
📣 READ CAREFULLY BEFORE CREATING THIS PR 📣
1️⃣ This PR template is exclusively for FIX
2️⃣ The PR title must start from "fix:"
3️⃣ The PR title must be written in lowercase
4️⃣ The topic must be provided with requested below information
-->

## Standards checklist:
- [x] The PR title is descriptive
- [x] There is no PR that addresses this issue
- [x] The PR has self-explained commits history
- [x] The code is mine or has Apache-2.0 compatible license
- [x] The code is efficient enough, it respects user resources
- [x] The code is stable and tested
- [x] There is new functionality, information is provided below

## Changes:
This fixes the Tor socks port matches the Tor browser's socks port. The Tor browser uses the same socks proxy port to run Tor as Bastyon. Both apps have no fallback mechanism, so only the first app could use Tor. The second app could not run Tor.

## Other comments:
...
